### PR TITLE
Initialize FurlanG2P skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,34 @@
+Byte-compiled / optimized / DLL files
+
+__pycache__/
+*.py[cod]
+*$py.class
+
+Distribution / packaging
+
+.build/
+dist/
+build/
+*.egg-info/
+
+Virtual environments
+
+.venv/
+venv/
+.env
+
+Editors
+
+.vscode/
+.idea/
+
+Pytest / coverage
+
+.pytest_cache/
+.coverage
+htmlcov/
+
+OS junk
+
+.DS_Store
+Thumbs.db

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+AGENTS BRIEFING
+
+This repository is scaffolded for future automated agents (e.g., codegen, test bots). The current state is a deliberate skeleton:
+
+- All core algorithms raise NotImplementedError.
+- Public interfaces are stable, so agents can implement internals without reshaping the API.
+- Tests check importability, CLI help, and that unimplemented methods raise NotImplementedError.
+
+Agent tasks (suggested):
+
+- Implement text normalization rules and configuration loading.
+- Implement tokenization with abbreviation handling and sentence/word splitting.
+- Implement G2P: lexicon lookup, LTS rules engine, and phoneme inventory management.
+- Implement phonology: syllabification and stress assignment.
+- Wire services into CLI subcommands; add CSV batch processing.
+- Add real tests, fixtures, and golden sets.
+
+Coding standards:
+
+- Type hints everywhere.
+- Docstrings with argument/return types and examples.
+- Keep runtime deps minimal; add extras behind optional groups if needed.
+- Follow ruff/black/mypy configs defined in pyproject.toml.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,39 @@
+FurlanG2P
+
+FurlanG2P is a library-first skeleton for building a grapheme-to-phoneme (G2P) and text normalization toolkit, designed for TTS prototyping. This repository currently ships a clean, scalable structure with interfaces, services, and a CLI scaffold — domain logic is intentionally unimplemented and should be filled in later.
+
+Features (skeleton)
+
+- src/ layout, Python ≥ 3.10
+- Clear module boundaries (core, normalization, tokenization, g2p, phonology, services, cli, config)
+- Public API via furlan_g2p.__init__
+- CLI entrypoint: furlang2p
+- Tests using pytest
+
+Install (editable)
+
+```bash
+pip install -e ".[dev]"
+```
+
+CLI
+
+```bash
+furlang2p --help
+```
+
+Library usage
+
+```python
+from furlan_g2p import Normalizer, Tokenizer, G2PPhonemizer
+
+# Instantiate and call methods (these raise NotImplementedError in the skeleton)
+```
+
+Contributing
+
+Open issues and PRs are welcome.
+
+License
+
+MIT

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,8 @@
+Examples
+
+This folder will contain runnable examples once the core logic is implemented.
+For now, see the CLI help:
+
+```
+furlang2p --help
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,69 @@
+[build-system]
+requires = ["hatchling>=1.25.0"]
+build-backend = "hatchling.build"
+
+[project]
+name = "furlang2p"
+version = "0.1.0"
+description = "FurlanG2P: a scalable, library-first G2P and text normalization toolkit (skeleton)."
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "MIT" }
+authors = [
+  { name = "Your Name", email = "you@example.com" }
+]
+keywords = ["g2p", "text-normalization", "tts", "nlp", "phonemization"]
+classifiers = [
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3 :: Only",
+  "License :: OSI Approved :: MIT License",
+  "Operating System :: OS Independent",
+]
+dependencies = [
+  "click>=8.1.7",
+]
+
+[project.optional-dependencies]
+dev = [
+  "pytest>=8.0.0",
+  "pytest-cov>=4.1.0",
+  "mypy>=1.10.0",
+  "ruff>=0.5.0",
+  "black>=24.4.0",
+  "types-click>=7.1.8",
+]
+
+[project.urls]
+Homepage = "https://github.com/yourname/FurlanG2P"
+Issues = "https://github.com/yourname/FurlanG2P/issues"
+
+[project.scripts]
+furlang2p = "furlan_g2p.cli.app:main"
+
+[tool.black]
+line-length = 100
+target-version = ["py310"]
+
+[tool.ruff]
+line-length = 100
+select = ["E", "F", "I", "UP", "B"]
+ignore = []
+target-version = "py310"
+
+[tool.mypy]
+python_version = "3.10"
+strict = true
+warn_unused_ignores = true
+disallow_untyped_defs = true
+disallow_any_unimported = true
+no_implicit_optional = true
+warn_return_any = true
+warn_unused_configs = true
+
+[tool.pytest.ini_options]
+minversion = "8.0"
+addopts = "-q"
+testpaths = ["tests"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/furlan_g2p"]

--- a/scripts/generate_phonemes.py
+++ b/scripts/generate_phonemes.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+"""Example script entry (skeleton)."""
+
+from __future__ import annotations
+
+from furlan_g2p.services.pipeline import PipelineService
+
+
+def main() -> None:
+    """Run the example pipeline (unimplemented)."""
+    _ = PipelineService()
+    raise NotImplementedError("Example script is not implemented yet.")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/src/furlan_g2p/__init__.py
+++ b/src/furlan_g2p/__init__.py
@@ -1,0 +1,37 @@
+"""FurlanG2P public API."""
+
+from __future__ import annotations
+
+from importlib import metadata
+
+from .core.interfaces import (
+    IG2PPhonemizer,
+    INormalizer,
+    IStressAssigner,
+    ISyllabifier,
+    ITokenizer,
+)
+from .g2p.phonemizer import G2PPhonemizer
+from .normalization.normalizer import Normalizer
+from .phonology.stress import StressAssigner
+from .phonology.syllabifier import Syllabifier
+from .tokenization.tokenizer import Tokenizer
+
+try:
+    version = metadata.version("furlang2p")
+except metadata.PackageNotFoundError:  # pragma: no cover
+    version = "0.0.0"
+
+__all__ = [
+    "version",
+    "INormalizer",
+    "ITokenizer",
+    "IG2PPhonemizer",
+    "ISyllabifier",
+    "IStressAssigner",
+    "Normalizer",
+    "Tokenizer",
+    "G2PPhonemizer",
+    "Syllabifier",
+    "StressAssigner",
+]

--- a/src/furlan_g2p/cli/__init__.py
+++ b/src/furlan_g2p/cli/__init__.py
@@ -1,0 +1,7 @@
+"""CLI package (skeleton)."""
+
+from __future__ import annotations
+
+from .app import cli, main
+
+__all__ = ["cli", "main"]

--- a/src/furlan_g2p/cli/app.py
+++ b/src/furlan_g2p/cli/app.py
@@ -1,0 +1,55 @@
+"""Command-line interface for FurlanG2P (skeleton)."""
+
+from __future__ import annotations
+
+import sys
+
+import click
+
+from ..services.pipeline import PipelineService
+
+
+@click.group(context_settings={"help_option_names": ["-h", "--help"]})
+def cli() -> None:
+    """FurlanG2P command-line interface (skeleton)."""
+    # click requires a function body
+    pass
+
+
+@cli.command("normalize")
+@click.argument("text", nargs=-1)
+def cmd_normalize(text: tuple[str, ...]) -> None:
+    """Normalize text and print it."""
+    PipelineService()
+    _ = " ".join(text)
+    raise NotImplementedError("normalize command is not implemented yet.")
+
+
+@cli.command("g2p")
+@click.argument("text", nargs=-1)
+def cmd_g2p(text: tuple[str, ...]) -> None:
+    """Convert text to phonemes and print them."""
+    PipelineService()
+    _ = " ".join(text)
+    raise NotImplementedError("g2p command is not implemented yet.")
+
+
+@cli.command("phonemize-csv")
+@click.option("--in", "inp", required=True, help="Input metadata CSV (LJSpeech-like).")
+@click.option("--out", "out", required=True, help="Output CSV with phonemes added.")
+@click.option("--delim", "delim", default="|", show_default=True, help="CSV delimiter.")
+def cmd_phonemize_csv(inp: str, out: str, delim: str) -> None:
+    """Batch phonemize an LJSpeech-like CSV file."""
+    PipelineService()
+    raise NotImplementedError("phonemize-csv command is not implemented yet.")
+
+
+def main() -> None:  # pragma: no cover - small wrapper
+    try:
+        cli(prog_name="furlang2p")
+    except NotImplementedError as e:  # pragma: no cover - placeholder behaviour
+        click.echo(f"[FurlanG2P skeleton] {e}", err=True)
+        sys.exit(2)
+
+
+__all__ = ["cli", "main"]

--- a/src/furlan_g2p/config/__init__.py
+++ b/src/furlan_g2p/config/__init__.py
@@ -1,0 +1,5 @@
+"""Config data structures and loading utilities (skeleton)."""
+
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/src/furlan_g2p/config/schemas.py
+++ b/src/furlan_g2p/config/schemas.py
@@ -1,0 +1,34 @@
+"""Dataclasses for configuration (skeleton)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(slots=True)
+class NormalizerConfig:
+    """Configuration for normalization rules."""
+
+    units_map: dict[str, str] = field(default_factory=dict)
+    acronyms_map: dict[str, str] = field(default_factory=dict)
+    ordinal_map: dict[str, str] = field(default_factory=dict)
+    pause_short: str = "_"
+    pause_long: str = "__"
+
+
+@dataclass(slots=True)
+class TokenizerConfig:
+    """Configuration for tokenization behavior."""
+
+    abbrev_no_split: set[str] = field(default_factory=set)
+
+
+@dataclass(slots=True)
+class G2PConfig:
+    """Configuration for G2P conversion."""
+
+    phoneme_inventory: list[str] = field(default_factory=list)
+    lexicon: dict[str, str] = field(default_factory=dict)
+
+
+__all__ = ["NormalizerConfig", "TokenizerConfig", "G2PConfig"]

--- a/src/furlan_g2p/core/__init__.py
+++ b/src/furlan_g2p/core/__init__.py
@@ -1,0 +1,5 @@
+"""Core types, interfaces, and exceptions."""
+
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/src/furlan_g2p/core/exceptions.py
+++ b/src/furlan_g2p/core/exceptions.py
@@ -1,0 +1,32 @@
+"""Custom exception hierarchy for FurlanG2P."""
+
+from __future__ import annotations
+
+
+class FurlanG2PError(Exception):
+    """Base exception for FurlanG2P."""
+
+
+class NormalizationError(FurlanG2PError):
+    """Raised when normalization fails."""
+
+
+class TokenizationError(FurlanG2PError):
+    """Raised when tokenization fails."""
+
+
+class G2PError(FurlanG2PError):
+    """Raised when G2P conversion fails."""
+
+
+class PhonologyError(FurlanG2PError):
+    """Raised for syllabification/stress assignment errors."""
+
+
+__all__ = [
+    "FurlanG2PError",
+    "NormalizationError",
+    "TokenizationError",
+    "G2PError",
+    "PhonologyError",
+]

--- a/src/furlan_g2p/core/interfaces.py
+++ b/src/furlan_g2p/core/interfaces.py
@@ -1,0 +1,65 @@
+"""Abstract base interfaces for FurlanG2P components."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Iterable
+
+
+class INormalizer(ABC):
+    """Interface for text normalization."""
+
+    @abstractmethod
+    def normalize(self, text: str) -> str:
+        """Return a normalized text string."""
+        raise NotImplementedError
+
+
+class ITokenizer(ABC):
+    """Interface for sentence/word tokenization."""
+
+    @abstractmethod
+    def split_sentences(self, text: str) -> list[str]:
+        """Split text into sentences."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def split_words(self, sentence: str) -> list[str]:
+        """Split a sentence into tokens/words (keeping pause markers if any)."""
+        raise NotImplementedError
+
+
+class IG2PPhonemizer(ABC):
+    """Interface for grapheme-to-phoneme conversion."""
+
+    @abstractmethod
+    def to_phonemes(self, tokens: Iterable[str]) -> list[str]:
+        """Map tokens to a flat sequence of phoneme symbols."""
+        raise NotImplementedError
+
+
+class ISyllabifier(ABC):
+    """Interface for syllabification."""
+
+    @abstractmethod
+    def syllabify(self, phonemes: Iterable[str]) -> list[list[str]]:
+        """Return a list of syllables, each as a list of phoneme strings."""
+        raise NotImplementedError
+
+
+class IStressAssigner(ABC):
+    """Interface for lexical or post-lexical stress assignment."""
+
+    @abstractmethod
+    def assign_stress(self, syllables: list[list[str]]) -> list[list[str]]:
+        """Return syllables with stress markers applied."""
+        raise NotImplementedError
+
+
+__all__ = [
+    "INormalizer",
+    "ITokenizer",
+    "IG2PPhonemizer",
+    "ISyllabifier",
+    "IStressAssigner",
+]

--- a/src/furlan_g2p/core/types.py
+++ b/src/furlan_g2p/core/types.py
@@ -1,0 +1,25 @@
+"""Common type aliases used across the project."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import NewType
+
+Phoneme = NewType("Phoneme", str)
+PhonemeSeq = NewType("PhonemeSeq", str)
+Token = NewType("Token", str)
+
+StrSequence = Sequence[str]
+StrList = list[str]
+StrTuple = tuple[str, ...]
+StrDict = dict[str, str]
+
+__all__ = [
+    "Phoneme",
+    "PhonemeSeq",
+    "Token",
+    "StrSequence",
+    "StrList",
+    "StrTuple",
+    "StrDict",
+]

--- a/src/furlan_g2p/g2p/__init__.py
+++ b/src/furlan_g2p/g2p/__init__.py
@@ -1,0 +1,9 @@
+"""G2P module (skeleton)."""
+
+from __future__ import annotations
+
+from .lexicon import Lexicon
+from .phonemizer import G2PPhonemizer
+from .rules import PhonemeRules
+
+__all__ = ["Lexicon", "PhonemeRules", "G2PPhonemizer"]

--- a/src/furlan_g2p/g2p/lexicon.py
+++ b/src/furlan_g2p/g2p/lexicon.py
@@ -1,0 +1,21 @@
+"""In-memory lexicon utilities (skeleton)."""
+
+from __future__ import annotations
+
+
+class Lexicon:
+    """In-memory lexicon for word -> phoneme sequence (space-separated string)."""
+
+    def __init__(self) -> None:
+        self._store: dict[str, str] = {}
+
+    def get(self, word: str) -> str | None:
+        """Retrieve the phoneme sequence for ``word``."""
+        raise NotImplementedError("Lexicon lookup is not implemented yet.")
+
+    def add(self, word: str, phonemes: str) -> None:
+        """Add a phoneme sequence for ``word``."""
+        raise NotImplementedError("Lexicon updates are not implemented yet.")
+
+
+__all__ = ["Lexicon"]

--- a/src/furlan_g2p/g2p/phonemizer.py
+++ b/src/furlan_g2p/g2p/phonemizer.py
@@ -1,0 +1,24 @@
+"""Grapheme-to-phoneme conversion utilities (skeleton)."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from ..core.interfaces import IG2PPhonemizer
+from .lexicon import Lexicon
+from .rules import PhonemeRules
+
+
+class G2PPhonemizer(IG2PPhonemizer):
+    """Phonemizer that combines a lexicon and LTS rules (skeleton)."""
+
+    def __init__(self, lexicon: Lexicon | None = None, rules: PhonemeRules | None = None) -> None:
+        self.lexicon = lexicon or Lexicon()
+        self.rules = rules or PhonemeRules()
+
+    def to_phonemes(self, tokens: Iterable[str]) -> list[str]:
+        """Convert token strings into a flat list of phoneme symbols."""
+        raise NotImplementedError("Phonemization is not implemented yet.")
+
+
+__all__ = ["G2PPhonemizer"]

--- a/src/furlan_g2p/g2p/rules.py
+++ b/src/furlan_g2p/g2p/rules.py
@@ -1,0 +1,19 @@
+"""Letter-to-sound rules engine (skeleton)."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+
+class PhonemeRules:
+    """Letter-to-sound rules engine (skeleton)."""
+
+    def __init__(self, phoneme_inventory: Iterable[str] | None = None) -> None:
+        self._inventory = set(phoneme_inventory or ())
+
+    def apply(self, word: str) -> list[str]:
+        """Return a list of phoneme symbols for the given word."""
+        raise NotImplementedError("LTS rules are not implemented yet.")
+
+
+__all__ = ["PhonemeRules"]

--- a/src/furlan_g2p/main.py
+++ b/src/furlan_g2p/main.py
@@ -1,0 +1,8 @@
+"""Module entry point for ``python -m furlan_g2p``."""
+
+from __future__ import annotations
+
+from .cli.app import main
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/src/furlan_g2p/normalization/__init__.py
+++ b/src/furlan_g2p/normalization/__init__.py
@@ -1,0 +1,7 @@
+"""Normalization module (skeleton)."""
+
+from __future__ import annotations
+
+from .normalizer import Normalizer
+
+__all__ = ["Normalizer"]

--- a/src/furlan_g2p/normalization/normalizer.py
+++ b/src/furlan_g2p/normalization/normalizer.py
@@ -1,0 +1,28 @@
+"""Text normalization utilities (skeleton)."""
+
+from __future__ import annotations
+
+from ..config.schemas import NormalizerConfig
+from ..core.exceptions import NormalizationError  # noqa: F401
+from ..core.interfaces import INormalizer
+
+
+class Normalizer(INormalizer):
+    """Text normalizer (skeleton)."""
+
+    def __init__(self, config: NormalizerConfig | None = None) -> None:
+        self.config = config or NormalizerConfig()
+
+    def normalize(self, text: str) -> str:
+        """Normalize raw input text into a canonical, speakable form.
+
+        Args:
+            text: Raw input text.
+
+        Raises:
+            NormalizationError: If the text cannot be normalized.
+        """
+        raise NotImplementedError("Normalization logic is not implemented yet.")
+
+
+__all__ = ["Normalizer"]

--- a/src/furlan_g2p/phonology/__init__.py
+++ b/src/furlan_g2p/phonology/__init__.py
@@ -1,0 +1,8 @@
+"""Phonology helpers (skeleton)."""
+
+from __future__ import annotations
+
+from .stress import StressAssigner
+from .syllabifier import Syllabifier
+
+__all__ = ["Syllabifier", "StressAssigner"]

--- a/src/furlan_g2p/phonology/stress.py
+++ b/src/furlan_g2p/phonology/stress.py
@@ -1,0 +1,16 @@
+"""Stress assignment helpers (skeleton)."""
+
+from __future__ import annotations
+
+from ..core.interfaces import IStressAssigner
+
+
+class StressAssigner(IStressAssigner):
+    """Stress assignment (skeleton)."""
+
+    def assign_stress(self, syllables: list[list[str]]) -> list[list[str]]:
+        """Apply stress markers to ``syllables``."""
+        raise NotImplementedError("Stress assignment is not implemented yet.")
+
+
+__all__ = ["StressAssigner"]

--- a/src/furlan_g2p/phonology/syllabifier.py
+++ b/src/furlan_g2p/phonology/syllabifier.py
@@ -1,0 +1,18 @@
+"""Syllabification helpers (skeleton)."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from ..core.interfaces import ISyllabifier
+
+
+class Syllabifier(ISyllabifier):
+    """Syllabifier (skeleton)."""
+
+    def syllabify(self, phonemes: Iterable[str]) -> list[list[str]]:
+        """Split a phoneme sequence into syllables."""
+        raise NotImplementedError("Syllabification is not implemented yet.")
+
+
+__all__ = ["Syllabifier"]

--- a/src/furlan_g2p/services/__init__.py
+++ b/src/furlan_g2p/services/__init__.py
@@ -1,0 +1,8 @@
+"""Service layer (skeleton). Pipelines and I/O helpers live here."""
+
+from __future__ import annotations
+
+from .io_service import IOService
+from .pipeline import PipelineService
+
+__all__ = ["PipelineService", "IOService"]

--- a/src/furlan_g2p/services/io_service.py
+++ b/src/furlan_g2p/services/io_service.py
@@ -1,0 +1,18 @@
+"""File I/O helpers (skeleton)."""
+
+from __future__ import annotations
+
+
+class IOService:
+    """File I/O helpers (skeleton)."""
+
+    def read_text(self, path: str) -> str:
+        """Read text from ``path``."""
+        raise NotImplementedError("read_text is not implemented yet.")
+
+    def write_text(self, path: str, data: str) -> None:
+        """Write ``data`` to ``path``."""
+        raise NotImplementedError("write_text is not implemented yet.")
+
+
+__all__ = ["IOService"]

--- a/src/furlan_g2p/services/pipeline.py
+++ b/src/furlan_g2p/services/pipeline.py
@@ -1,0 +1,31 @@
+"""High-level pipeline service (skeleton)."""
+
+from __future__ import annotations
+
+from ..g2p.phonemizer import G2PPhonemizer
+from ..normalization.normalizer import Normalizer
+from ..phonology.stress import StressAssigner
+from ..phonology.syllabifier import Syllabifier
+from ..tokenization.tokenizer import Tokenizer
+
+
+class PipelineService:
+    """Orchestrates normalization -> tokenization -> G2P -> phonology."""
+
+    def __init__(self) -> None:
+        self.normalizer = Normalizer()
+        self.tokenizer = Tokenizer()
+        self.phonemizer = G2PPhonemizer()
+        self.syllabifier = Syllabifier()
+        self.stress = StressAssigner()
+
+    def process_text(self, text: str) -> tuple[str, list[str]]:
+        """Return ``(normalized_text, phoneme_sequence_as_list)``."""
+        raise NotImplementedError("Pipeline processing is not implemented yet.")
+
+    def process_csv(self, input_csv_path: str, output_csv_path: str, delimiter: str = "|") -> None:
+        """Phonemize an LJSpeech-like metadata CSV file."""
+        raise NotImplementedError("CSV batch processing is not implemented yet.")
+
+
+__all__ = ["PipelineService"]

--- a/src/furlan_g2p/tokenization/__init__.py
+++ b/src/furlan_g2p/tokenization/__init__.py
@@ -1,0 +1,7 @@
+"""Tokenization module (skeleton)."""
+
+from __future__ import annotations
+
+from .tokenizer import Tokenizer
+
+__all__ = ["Tokenizer"]

--- a/src/furlan_g2p/tokenization/tokenizer.py
+++ b/src/furlan_g2p/tokenization/tokenizer.py
@@ -1,0 +1,24 @@
+"""Sentence and word tokenization utilities (skeleton)."""
+
+from __future__ import annotations
+
+from ..config.schemas import TokenizerConfig
+from ..core.interfaces import ITokenizer
+
+
+class Tokenizer(ITokenizer):
+    """Sentence and word tokenizer (skeleton)."""
+
+    def __init__(self, config: TokenizerConfig | None = None) -> None:
+        self.config = config or TokenizerConfig()
+
+    def split_sentences(self, text: str) -> list[str]:
+        """Split raw text into sentences."""
+        raise NotImplementedError("Sentence splitting is not implemented yet.")
+
+    def split_words(self, sentence: str) -> list[str]:
+        """Split a sentence into tokens/words."""
+        raise NotImplementedError("Word tokenization is not implemented yet.")
+
+
+__all__ = ["Tokenizer"]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+"""Test package marker."""
+
+from __future__ import annotations

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+"""Reserved for shared fixtures when real tests are added."""
+
+from __future__ import annotations

--- a/tests/test_cli_help.py
+++ b/tests/test_cli_help.py
@@ -1,0 +1,14 @@
+"""Ensure that the CLI entry point prints help."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+
+
+def test_cli_help_runs() -> None:
+    exe = shutil.which("furlang2p")
+    assert exe is not None
+    proc = subprocess.run([exe, "--help"], capture_output=True, text=True)
+    assert proc.returncode == 0
+    assert "FurlanG2P" in proc.stdout or "Usage" in proc.stdout

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,11 @@
+"""Smoke tests for importability."""
+
+from __future__ import annotations
+
+import furlan_g2p
+from furlan_g2p import G2PPhonemizer, Normalizer, StressAssigner, Syllabifier, Tokenizer
+
+
+def test_imports() -> None:
+    assert furlan_g2p
+    assert all([Normalizer, Tokenizer, G2PPhonemizer, Syllabifier, StressAssigner])

--- a/tests/test_unimplemented.py
+++ b/tests/test_unimplemented.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from typing import Any, Callable
+
+import pytest
+
+from furlan_g2p.g2p.lexicon import Lexicon
+from furlan_g2p.g2p.phonemizer import G2PPhonemizer
+from furlan_g2p.g2p.rules import PhonemeRules
+from furlan_g2p.normalization.normalizer import Normalizer
+from furlan_g2p.phonology.stress import StressAssigner
+from furlan_g2p.phonology.syllabifier import Syllabifier
+from furlan_g2p.services.pipeline import PipelineService
+from furlan_g2p.tokenization.tokenizer import Tokenizer
+
+
+def expect_not_impl(fn: Callable[..., Any], *args: Any, **kwargs: Any) -> None:
+    with pytest.raises(NotImplementedError):
+        fn(*args, **kwargs)
+
+
+def test_normalizer_unimplemented() -> None:
+    n = Normalizer()
+    expect_not_impl(n.normalize, "text")
+
+
+def test_tokenizer_unimplemented() -> None:
+    t = Tokenizer()
+    expect_not_impl(t.split_sentences, "text.")
+    expect_not_impl(t.split_words, "text")
+
+
+def test_g2p_unimplemented() -> None:
+    lex = Lexicon()
+    rules = PhonemeRules()
+    g2p = G2PPhonemizer(lex, rules)
+    expect_not_impl(g2p.to_phonemes, ["hello"])
+
+
+def test_phonology_unimplemented() -> None:
+    s = Syllabifier()
+    expect_not_impl(s.syllabify, ["h", "e", "l", "o"])
+    a = StressAssigner()
+    expect_not_impl(a.assign_stress, [["h", "e"], ["l", "o"]])
+
+
+def test_pipeline_unimplemented() -> None:
+    p = PipelineService()
+    expect_not_impl(p.process_text, "hello world")
+    expect_not_impl(p.process_csv, "in.csv", "out.csv")


### PR DESCRIPTION
## Summary
- scaffold FurlanG2P library with src/ layout and public API exports
- add Click-based CLI skeleton and pipeline service stubs
- configure tooling and tests for NotImplemented placeholders

## Testing
- `python -m pip install -e .[dev]`
- `ruff check .`
- `black --check .`
- `mypy .`
- `pytest`