### PR TITLE
Add experimental Friulian normalizer, rule engine and lexicon entries

### DIFF
--- a/docs/rationale.md
+++ b/docs/rationale.md
@@ -1,0 +1,26 @@
+# Rule rationale
+
+This repository treats the packaged lexicon as the authoritative source for
+"gold" items.  Pronunciations in the lexicon must match their cited sources
+exactly.  Phrase-level tests only check composition of these entries and are not
+considered gold.
+
+## Rule order
+
+The experimental rule engine applies rules from longest to shortest context:
+
+1. `cj` → `c` and `gj` → `ɟ` (palatal stops). [ARLeF – GRAFIE]
+2. `ch`/`gh` harden `c`/`g` before front vowels. [ARLeF – GRAFIE]
+3. `c` before `e i ê î` → `t͡ʃ`; `ç` always → `t͡ʃ`. [ARLeF – GRAFIE]
+4. Intervocalic `s` → `z`; `ss` remains voiceless. [ìsule on Wiktionary]
+5. Circumflex vowels map to long monophthongs. [ARLeF – Lezione 7; Wikipedia – Friulian language]
+
+These rules intentionally avoid sandhi and stress except for length marks from
+the lexicon.
+
+## Sources
+
+- ARLeF – *GRAFIE* <https://arlef.it/wp-content/uploads/2017/03/RegoleDellaGrafia.pdf>
+- ARLeF – *Dut par furlan*, Lezione 7 <https://arlef.it/wp-content/uploads/2020/07/DPF-Ud-07.pdf>
+- Wikipedia – *Friulian language* <https://en.wikipedia.org/wiki/Friulian_language>
+- Wiktionary lemma pages cited in tests.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
 dev = [
   "pytest>=8.0.0",
   "pytest-cov>=4.1.0",
+  "hypothesis>=6.0.0",
   "mypy>=1.10.0",
   "ruff>=0.5.0",
   "black>=24.4.0",

--- a/src/furlan_g2p/data/__init__.py
+++ b/src/furlan_g2p/data/__init__.py
@@ -1,4 +1,3 @@
 """Packaged data for FurlanG2P."""
 
 __all__: list[str] = []
-

--- a/src/furlan_g2p/data/seed_lexicon.tsv
+++ b/src/furlan_g2p/data/seed_lexicon.tsv
@@ -17,3 +17,5 @@ cjaval	/caˈval/	[]	https://en.wiktionary.org/wiki/cjaval
 pît	/piːt/	["/peit/"]	https://en.wiktionary.org/wiki/p%C3%AEt
 mûr	/muːr/	[]	https://en.wiktionary.org/wiki/m%C3%BBr
 côr	/kɔːr/	[]	https://en.wiktionary.org/wiki/c%C3%B4r
+cjase	/ˈca.ze/	[]	https://en.wiktionary.org/wiki/cjase
+cjandele	/caɳˈdɛ.le/	[]	https://en.wiktionary.org/wiki/cjandele

--- a/src/furlan_g2p/g2p/__init__.py
+++ b/src/furlan_g2p/g2p/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from .lexicon import Lexicon
 from .phonemizer import G2PPhonemizer
+from .rule_engine import RuleEngine
 from .rules import PhonemeRules
 
-__all__ = ["Lexicon", "PhonemeRules", "G2PPhonemizer"]
+__all__ = ["Lexicon", "PhonemeRules", "G2PPhonemizer", "RuleEngine"]

--- a/src/furlan_g2p/g2p/rule_engine.py
+++ b/src/furlan_g2p/g2p/rule_engine.py
@@ -1,0 +1,109 @@
+"""Experimental rule-based orthography to IPA converter.
+
+This module implements a small ordered set of rules derived from the official
+ARLeF orthography guidelines and a few cited lemmas.  It is intentionally
+limited and exists in parallel to the unfinished public API.
+"""
+
+import unicodedata
+from functools import lru_cache
+
+# Digraph precedence handled explicitly in the main loop to avoid regex backtracking.
+# Vowel inventory for quick context checks.
+_VOWELS = "aâeêiîoôuûàèìòù"
+_LONG_VOWELS = {
+    "â": "aː",
+    "ê": "eː",
+    "î": "iː",
+    "ô": "oː",
+    "û": "uː",
+}
+
+
+def _is_vowel(ch: str) -> bool:
+    return ch in _VOWELS
+
+
+def _between_vowels(word: str, i: int) -> bool:
+    return 0 < i < len(word) - 1 and _is_vowel(word[i - 1]) and _is_vowel(word[i + 1])
+
+
+class RuleEngine:
+    """Convert Friulian orthography to a narrow subset of IPA.
+
+    The rules are ordered roughly from longest match (digraphs) to single
+    letters.  They cover only a handful of contrasts needed by the unit tests:
+
+    - ``cj`` → ``c`` and ``gj`` → ``ɟ`` (palatal stops) [ARLeF GRAFIE].
+    - ``ch``/``gh`` harden ``c``/``g`` before front vowels.
+    - ``c`` before ``e i ê î`` → ``t͡ʃ``; ``ç`` → ``t͡ʃ`` elsewhere.
+    - Intervocalic ``s`` → ``z`` but ``ss`` stays ``s``.
+    - Long vowels with circumflex get a length mark.
+
+    Stress assignment, sandhi and many other phenomena are intentionally out of
+    scope for now.
+    """
+
+    def __init__(self) -> None:
+        pass
+
+    @lru_cache(maxsize=2048)  # noqa: B019 - deliberate cache on bound method
+    def convert(self, word: str) -> str:
+        """Return a best-effort IPA transcription of ``word``.
+
+        The implementation is deterministic and side-effect free, making it safe
+        to cache.
+        """
+        if not word:
+            return "/"
+
+        s = unicodedata.normalize("NFC", word.lower())
+        out: list[str] = []
+        i = 0
+        while i < len(s):
+            if s.startswith("cj", i):
+                out.append("c")
+                i += 2
+                continue
+            if s.startswith("gj", i):
+                out.append("ɟ")
+                i += 2
+                continue
+            if s.startswith("ch", i):
+                out.append("k")
+                i += 2
+                continue
+            if s.startswith("gh", i):
+                out.append("ɡ")
+                i += 2
+                continue
+            if s.startswith("ss", i):
+                out.append("s")
+                i += 2
+                continue
+
+            ch = s[i]
+            if ch == "ç":
+                out.append("t͡ʃ")
+            elif ch == "c":
+                nxt = s[i + 1] if i + 1 < len(s) else ""
+                out.append("t͡ʃ" if nxt in "eêiî" else "k")
+            elif ch == "s":
+                out.append("z" if _between_vowels(s, i) else "s")
+            elif ch in _LONG_VOWELS:
+                out.append(_LONG_VOWELS[ch])
+            elif ch in _VOWELS:
+                out.append({"e": "e", "o": "o"}.get(ch, ch))
+            elif ch == "j":
+                out.append("j")
+            elif ch == "g":
+                out.append("ɡ")
+            elif ch == "r":
+                out.append("r")
+            else:
+                out.append(ch)
+            i += 1
+        return f"/{''.join(out)}/"
+
+
+__all__ = ["RuleEngine"]

--- a/src/furlan_g2p/g2p/rules.py
+++ b/src/furlan_g2p/g2p/rules.py
@@ -124,4 +124,3 @@ class PhonemeRules:
 
 
 __all__ = ["orth_to_ipa_basic", "PhonemeRules"]
-

--- a/src/furlan_g2p/normalization/__init__.py
+++ b/src/furlan_g2p/normalization/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from .experimental_normalizer import ExperimentalNormalizer
 from .normalizer import Normalizer
 
-__all__ = ["Normalizer"]
+__all__ = ["Normalizer", "ExperimentalNormalizer"]

--- a/src/furlan_g2p/normalization/experimental_normalizer.py
+++ b/src/furlan_g2p/normalization/experimental_normalizer.py
@@ -1,0 +1,50 @@
+"""Experimental text normalizer.
+
+The public :class:`Normalizer` class is still a stub that raises
+``NotImplementedError``.  This module offers a small, opt-in normalizer used by
+unit tests to exercise downstream components without touching the public API.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from functools import lru_cache
+
+# Map curly apostrophes to straight ASCII ones.
+_APOSTROPHES_RE = re.compile("[\u2019\u2018\u02bc]")
+# Leading/trailing punctuation to strip; internal apostrophes are preserved.
+_STRIP_RE = re.compile(r"^[\W_]+|[\W_]+$", re.UNICODE)
+
+
+class ExperimentalNormalizer:
+    """Normalize and tokenize text.
+
+    Steps:
+    1. Unicode NFC normalization.
+    2. Map curly apostrophes to ASCII ``'``.
+    3. Lowercase.
+    4. Strip leading/trailing punctuation per token.
+    5. Tokenize on whitespace.
+    """
+
+    def __init__(self) -> None:
+        pass
+
+    @lru_cache(maxsize=1024)  # noqa: B019 - deliberate cache on bound method
+    def normalize(self, text: str) -> list[str]:
+        """Return a list of normalized tokens."""
+        if not text:
+            return []
+        s = unicodedata.normalize("NFC", text)
+        s = _APOSTROPHES_RE.sub("'", s)
+        s = s.lower()
+        tokens: list[str] = []
+        for raw in s.split():
+            token = _STRIP_RE.sub("", raw)
+            if token:
+                tokens.append(token)
+        return tokens
+
+
+__all__ = ["ExperimentalNormalizer"]

--- a/tests/test_data_integrity.py
+++ b/tests/test_data_integrity.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
 import csv
+import json
 from importlib import resources
+from urllib.parse import urlparse
 
 
 def test_seed_lexicon_tsv_is_well_formed() -> None:
-    with resources.files("furlan_g2p.data").joinpath("seed_lexicon.tsv").open(
-        "r", encoding="utf-8"
-    ) as f:
+    with (
+        resources.files("furlan_g2p.data")
+        .joinpath("seed_lexicon.tsv")
+        .open("r", encoding="utf-8") as f
+    ):
         reader = csv.DictReader(f, delimiter="\t")
         rows = list(reader)
     assert rows, "seed_lexicon.tsv is empty"
@@ -16,4 +20,12 @@ def test_seed_lexicon_tsv_is_well_formed() -> None:
     # no duplicates by lowercase key
     keys = [r["word"].lower() for r in rows]
     assert len(keys) == len(set(keys)), "duplicate entries detected"
-
+    for row in rows:
+        word = row["word"]
+        assert word == word.lower(), "word keys must be lowercase"
+        # variants_json must be valid JSON list
+        variants = json.loads(row["variants_json"] or "[]")
+        assert isinstance(variants, list)
+        # simple URL validation
+        url = urlparse(row["source"])
+        assert url.scheme and url.netloc, "invalid source URL"

--- a/tests/test_lexicon_gold.py
+++ b/tests/test_lexicon_gold.py
@@ -71,4 +71,3 @@ def test_variants_present_for_selected(lex: Lexicon) -> None:
 
 def test_unknown_returns_none(lex: Lexicon) -> None:
     assert lex.get("nonexistent") is None
-

--- a/tests/test_lexicon_gold_extra.py
+++ b/tests/test_lexicon_gold_extra.py
@@ -1,0 +1,37 @@
+"""Additional gold lemma tests sourced from Wiktionary.
+
+Each test asserts the exact IPA transcription as provided on the lemma's
+Wiktionary page.  These are "gold" items: they come from curated sources and
+should only fail if the lexicon diverges from the cited reference.
+"""
+
+from furlan_g2p.g2p.lexicon import Lexicon
+
+
+def _lex() -> Lexicon:
+    return Lexicon.load_seed()
+
+
+def test_isule() -> None:
+    """https://en.wiktionary.org/wiki/%C3%ACsule"""
+    assert _lex().get("ìsule") == "/ˈi.zu.le/"
+
+
+def test_glace() -> None:
+    """https://en.wiktionary.org/wiki/glace"""
+    assert _lex().get("glace") == "/ˈɡlat͡ʃe/"
+
+
+def test_glac_cedilla() -> None:
+    """https://en.wiktionary.org/wiki/gla%C3%A7"""
+    assert _lex().get("glaç") == "/ˈɡlat͡ʃ/"
+
+
+def test_cjase() -> None:
+    """https://en.wiktionary.org/wiki/cjase"""
+    assert _lex().get("cjase") == "/ˈca.ze/"
+
+
+def test_cjandele() -> None:
+    """https://en.wiktionary.org/wiki/cjandele"""
+    assert _lex().get("cjandele") == "/caɳˈdɛ.le/"

--- a/tests/test_normalizer.py
+++ b/tests/test_normalizer.py
@@ -1,0 +1,34 @@
+"""Tests for the experimental normalizer."""
+
+import unicodedata
+
+from hypothesis import given
+from hypothesis import strategies as st
+
+from furlan_g2p.normalization.experimental_normalizer import ExperimentalNormalizer
+
+norm = ExperimentalNormalizer()
+
+
+def test_apostrophes_and_tokenization() -> None:
+    text = "L’cjase, ‘bêle’!"
+    assert norm.normalize(text) == ["l'cjase", "bêle"]
+
+
+def test_nfc_normalization() -> None:
+    # "a" + COMBINING CIRCUMFLEX should collapse to single code point
+    text = "a\u0302"
+    tokens = norm.normalize(text)
+    assert tokens == ["â"]
+    # ensure the token is NFC
+    assert unicodedata.is_normalized("NFC", tokens[0])
+
+
+ALPHABET = "abcçdefghilmnopqrstuvzâêîôûàèìòù'’ \t.,!?"
+
+
+@given(st.text(alphabet=ALPHABET, max_size=20))
+def test_idempotence(s: str) -> None:
+    tokens = norm.normalize(s)
+    recombined = " ".join(tokens)
+    assert norm.normalize(recombined) == tokens

--- a/tests/test_phrase_compositional.py
+++ b/tests/test_phrase_compositional.py
@@ -1,0 +1,24 @@
+"""Non-gold composition tests.
+
+These tests only verify that IPA strings from gold lemmas compose without sandhi
+when forming short phrases.  The resulting phrase pronunciations are *not*
+authoritative.
+"""
+
+from furlan_g2p.g2p.lexicon import Lexicon
+
+
+def test_isule_cjase_phrase() -> None:
+    lex = Lexicon.load_seed()
+    words = ["ìsule", "cjase"]
+    ipa = [lex.get(w) or "" for w in words]
+    assert all(ipa)
+    assert " ".join(ipa) == "/ˈi.zu.le/ /ˈca.ze/"
+
+
+def test_glace_cjandele_phrase() -> None:
+    lex = Lexicon.load_seed()
+    words = ["glace", "cjandele"]
+    ipa = [lex.get(w) or "" for w in words]
+    assert all(ipa)
+    assert " ".join(ipa) == "/ˈɡlat͡ʃe/ /caɳˈdɛ.le/"

--- a/tests/test_rule_engine_properties.py
+++ b/tests/test_rule_engine_properties.py
@@ -1,0 +1,16 @@
+"""Property tests for the experimental rule engine."""
+
+from hypothesis import given
+from hypothesis import strategies as st
+
+from furlan_g2p.g2p.rule_engine import RuleEngine
+
+ALPHABET = "abcçdefghijlmnoprstuvzâêîôûàèìòù"
+IPA_CHARS = set("/abcdefghijklmnopqrstuvwxyzɡɟt͡ʃʃzːˈɳɛàèìòù")
+
+
+@given(st.text(alphabet=ALPHABET, min_size=1, max_size=10))
+def test_outputs_are_ipa_only(s: str) -> None:
+    eng = RuleEngine()
+    out = eng.convert(s)
+    assert all(ch in IPA_CHARS for ch in out)

--- a/tests/test_rules_contextual.py
+++ b/tests/test_rules_contextual.py
@@ -1,0 +1,34 @@
+"""Smoke tests for the experimental rule engine.
+
+These are *not* gold pronunciations; they merely check that individual
+orthographic contexts map to the expected IPA segments.
+"""
+
+import pytest
+
+from furlan_g2p.g2p.rule_engine import RuleEngine
+
+
+@pytest.fixture(scope="module")
+def eng() -> RuleEngine:
+    return RuleEngine()
+
+
+def test_intervocalic_s_and_ss(eng: RuleEngine) -> None:
+    assert eng.convert("asa") == "/aza/"
+    assert eng.convert("assa") == "/asa/"
+
+
+def test_ce_ci_and_c_elsewhere(eng: RuleEngine) -> None:
+    assert eng.convert("ce") == "/t͡ʃe/"
+    assert eng.convert("ci") == "/t͡ʃi/"
+    assert eng.convert("ca") == "/ka/"
+
+
+def test_cedilla(eng: RuleEngine) -> None:
+    assert eng.convert("ça") == "/t͡ʃa/"
+
+
+def test_cj_and_gj(eng: RuleEngine) -> None:
+    assert eng.convert("cjala") == "/cala/"
+    assert eng.convert("gjala") == "/ɟala/"

--- a/tests/test_rules_minimal.py
+++ b/tests/test_rules_minimal.py
@@ -21,4 +21,3 @@ from furlan_g2p.g2p.rules import orth_to_ipa_basic
 )
 def test_minimal_rules(word: str, expected: str) -> None:
     assert orth_to_ipa_basic(word) == expected
-


### PR DESCRIPTION
## Summary
- expand gold lexicon and document rule rationale
- introduce cached experimental normalizer and rule engine modules
- add property tests, phrase composition, and contextual rule checks

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `pytest`