### PR TITLE
Add gn digraph rule, update IPA whitelist, and set up CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: "pip"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .[dev]
+      - name: Ruff
+        run: ruff check .
+      - name: Black
+        run: black --check .
+      - name: Mypy
+        run: mypy .
+      - name: Pytest
+        run: pytest -q

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ Pytest / coverage
 .pytest_cache/
 .coverage
 htmlcov/
+.hypothesis/
 
 OS junk
 

--- a/src/furlan_g2p/g2p/rule_engine.py
+++ b/src/furlan_g2p/g2p/rule_engine.py
@@ -77,6 +77,10 @@ class RuleEngine:
                 out.append("ɡ")
                 i += 2
                 continue
+            if s.startswith("gn", i):
+                out.append("ɲ")
+                i += 2
+                continue
             if s.startswith("ss", i):
                 out.append("s")
                 i += 2

--- a/tests/test_rule_engine_properties.py
+++ b/tests/test_rule_engine_properties.py
@@ -6,7 +6,7 @@ from hypothesis import strategies as st
 from furlan_g2p.g2p.rule_engine import RuleEngine
 
 ALPHABET = "abcçdefghijlmnoprstuvzâêîôûàèìòù"
-IPA_CHARS = set("/abcdefghijklmnopqrstuvwxyzɡɟt͡ʃʃzːˈɳɛàèìòù")
+IPA_CHARS = set("/abcdefhijklmnoprstuvzàèìòùɡɟɲʃ͡ː")
 
 
 @given(st.text(alphabet=ALPHABET, min_size=1, max_size=10))

--- a/tests/test_rules_contextual.py
+++ b/tests/test_rules_contextual.py
@@ -32,3 +32,10 @@ def test_cedilla(eng: RuleEngine) -> None:
 def test_cj_and_gj(eng: RuleEngine) -> None:
     assert eng.convert("cjala") == "/cala/"
     assert eng.convert("gjala") == "/ɟala/"
+
+
+def test_gn(eng: RuleEngine) -> None:
+    assert eng.convert("agna") == "/aɲa/"
+    assert eng.convert("gn") == "/ɲ/"
+    assert eng.convert("gno") == "/ɲo/"
+    assert eng.convert("ugna") == "/uɲa/"


### PR DESCRIPTION
## Summary
- handle `gn` as a digraph producing `ɲ` ahead of single-letter rules
- broaden IPA whitelist to cover `ɲ` and all emitted symbols
- add smoke tests for the new rule
- introduce GitHub Actions workflow with linting, type-checking and tests on Python 3.10-3.12

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `pytest -q`