### PR TITLE
docs: improve README and add VS Code tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,8 @@ venv/
 
 Editors
 
-.vscode/
+.vscode/*
+!.vscode/tasks.json
 .idea/
 
 Pytest / coverage

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,30 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Install dependencies",
+            "type": "shell",
+            "command": "pip install -e .[dev]"
+        },
+        {
+            "label": "Format",
+            "type": "shell",
+            "command": "isort . && black ."
+        },
+        {
+            "label": "Lint",
+            "type": "shell",
+            "command": "ruff check ."
+        },
+        {
+            "label": "Type check",
+            "type": "shell",
+            "command": "mypy src"
+        },
+        {
+            "label": "Test",
+            "type": "shell",
+            "command": "pytest -q"
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -1,24 +1,105 @@
 # FurlanG2P
 
-Friulian (Furlan) G2P library. This repository aims for a maintainable, test-driven path: start with a tiny gold lexicon (citable IPA) and a minimal, explicit ruleset; evolve toward full normalization, tokenization, G2P, and phonology.
+Tools and library code for converting Friulian (Furlan) text to phonemes. The
+project ships a small gold lexicon and a rule-based engine that together provide
+an experimental ``ipa`` command-line tool. Other pieces of the pipeline – text
+normalisation, tokenisation, full G2P and phonology – are present as skeletons
+and currently raise ``NotImplementedError``.
 
-## Status
+## Installation
 
-- ✅ Packaged seed lexicon with gold IPA.
-- ✅ Minimal rules: circumflex length; `ç`, `ce/ci` → `t͡ʃ`; `cj` → `c`; intervocalic `s` → `z`; basic `c/ch`, `g/gh`.
-- ⏳ CLI and pipeline remain unimplemented stubs (by design for now).
+1. Create and activate a virtual environment:
+
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate  # Windows: .venv\Scripts\activate
+   ```
+
+2. Install the project:
+
+   ```bash
+   pip install -e .
+   ```
+
+3. (Optional) Add development tools for linting, typing and tests:
+
+   ```bash
+   pip install -e .[dev]
+   ```
+
+## Usage
+
+The package exposes a ``furlang2p`` CLI. At present only the experimental
+``ipa`` subcommand does real work; the ``normalize``, ``g2p`` and
+``phonemize-csv`` commands are stubs that abort with ``NotImplementedError``.
+
+Phonemise short phrases via the seed lexicon with rule-based fallback:
+
+```bash
+furlang2p ipa ìsule glace
+# -> ˈi.zu.le ˈɡlat͡ʃe
+```
+
+Wrap each token in ``/slashes/`` or force rule-based conversion:
+
+```bash
+furlang2p ipa --with-slashes glaç
+furlang2p ipa --rules-only glaç
+```
+
+Underscores act as short/long pause markers and the ``--sep`` option controls
+output token separation:
+
+```bash
+furlang2p ipa --sep '|' _ ìsule __
+# -> _|ˈi.zu.le|__
+```
+
+See ``furlang2p ipa --help`` for full details.
+
+## Development
+
+Run the following checks before committing code:
+
+```bash
+isort .
+black .
+ruff check .
+mypy src
+pytest -q
+```
+
+## VS Code integration
+
+A ``.vscode/tasks.json`` file provides shortcuts for common actions:
+
+- **Install dependencies** – ``pip install -e .[dev]``
+- **Format** – run ``isort`` and ``black``
+- **Lint** – run ``ruff``
+- **Type check** – run ``mypy`` on ``src``
+- **Test** – execute ``pytest -q``
+
+From VS Code press ``Ctrl+Shift+B`` or run *Tasks: Run Task* from the Command
+Palette and choose the desired action.
 
 ## References
 
 Authoritative grammar/orthography (ARLeF):
-- **GRAFIE** (official orthography, cj/gj, c~ç, long vowels with circumflex): https://arlef.it/app/uploads/documenti/Grafie_cuadrileng%C3%A2l_ed2017.pdf
-- **Dut par furlan – Lezione 7** (when to write circumflex; patterns like `pôc`, `côr`): https://arlef.it/app/uploads/2020/12/dutparfurlan_lez-7-ita-def.pdf
 
-Overview of long vowels and dialectal diphthongization:
+- **GRAFIE** (official orthography, cj/gj, c~ç, long vowels with circumflex): https://arlef.it/app/uploads/documenti/Grafie_cuadrileng%C3%A2l_ed2017.pdf
+- **Dut par furlan – Lezione 7** (when to write circumflex; patterns like ``pôc``, ``côr``): https://arlef.it/app/uploads/2020/12/dutparfurlan_lez-7-ita-def.pdf
+
+Overview of long vowels and dialectal diphthongisation:
+
 - Wikipedia (Friulian language): https://en.wikipedia.org/wiki/Friulian_language
 
 Quick alphabet/pronunciation overview:
+
 - Omniglot: https://www.omniglot.com/writing/friulian.htm
 
-Gold IPA sources (Wiktionary) are embedded in `src/furlan_g2p/data/seed_lexicon.tsv` and cited in tests.
+Gold IPA sources (Wiktionary) are embedded in ``src/furlan_g2p/data/seed_lexicon.tsv`` and cited in tests.
 
+## Contributing
+
+Pull requests that flesh out the skeleton or expand test coverage are welcome.
+Please open an issue to discuss major changes.


### PR DESCRIPTION
## Summary
- expand README with installation, usage examples, development steps, and references
- document available CLI subcommand and add VS Code tasks for common workflows
- allow checking in the tasks file by updating gitignore

## Testing
- `isort .`
- `black .`
- `ruff check .`
- `mypy src`
- `pytest -q`