### PR TITLE
Add release workflow and initial packaging metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,49 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  bump-and-publish:
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+          cache: 'pip'
+      - name: Install Hatch
+        run: |
+          python -m pip install --upgrade pip
+          pip install hatch
+      - name: Bump patch version
+        id: bump
+        run: |
+          old_version=$(hatch version)
+          hatch version patch
+          new_version=$(hatch version)
+          echo "new_version=$new_version" >> "$GITHUB_OUTPUT"
+      - name: Commit and tag
+        env:
+          NEW_VERSION: ${{ steps.bump.outputs.new_version }}
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git commit -am "chore: bump version to $NEW_VERSION"
+          git tag "v$NEW_VERSION"
+          git push --follow-tags
+      - name: Build
+        run: hatch build
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+

--- a/README.md
+++ b/README.md
@@ -65,9 +65,17 @@ and currently raise ``NotImplementedError``.
 
 ## Installation
 
+### From PyPI
+
+```bash
+pip install furlang2p
+```
+
+### From source
+
 1. Create and activate a virtual environment (see Quick local run above).
 
-2. Install the project:
+2. Install the project in editable mode:
 
    ```bash
    pip install -e .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,13 @@ build-backend = "hatchling.build"
 
 [project]
 name = "furlang2p"
-version = "0.1.0"
+version = "0.0.1"
 description = "FurlanG2P: a scalable, library-first G2P and text normalization toolkit (skeleton)."
 readme = "README.md"
 requires-python = ">=3.10"
 license = { text = "MIT" }
 authors = [
-  { name = "Your Name", email = "you@example.com" }
+  { name = "FurlanG2P Team", email = "maintainers@example.com" }
 ]
 keywords = ["g2p", "text-normalization", "tts", "nlp", "phonemization"]
 classifiers = [
@@ -35,8 +35,8 @@ dev = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/yourname/FurlanG2P"
-Issues = "https://github.com/yourname/FurlanG2P/issues"
+Homepage = "https://github.com/furlan-g2p/FurlanG2P"
+Issues = "https://github.com/furlan-g2p/FurlanG2P/issues"
 
 [project.scripts]
 furlang2p = "furlan_g2p.cli.app:main"


### PR DESCRIPTION
## Summary
- initialize package metadata and set version to 0.0.1
- document PyPI installation method
- add release workflow that bumps patch version on merges to main and publishes to PyPI

## Testing
- `pip install -e .[dev]`
- `hatch run ruff check .`
- `hatch run black --check .`
- `hatch run mypy .`
- `hatch run pytest`