### PR TITLE
feat: expand normalizer with configurable rules

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,35 +14,38 @@ jobs:
     runs-on: ubuntu-latest
     environment: pypi
     steps:
-      - uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.x'
-          cache: 'pip'
-      - name: Install Hatch
-        run: |
-          python -m pip install --upgrade pip
-          pip install hatch
-      - name: Bump patch version
-        id: bump
-        run: |
-          old_version=$(hatch version)
-          hatch version patch
-          new_version=$(hatch version)
-          echo "new_version=$new_version" >> "$GITHUB_OUTPUT"
-      - name: Commit and tag
-        env:
-          NEW_VERSION: ${{ steps.bump.outputs.new_version }}
-        run: |
-          git config user.name github-actions
-          git config user.email github-actions@github.com
-          git commit -am "chore: bump version to $NEW_VERSION"
-          git tag "v$NEW_VERSION"
-          git push --follow-tags
-      - name: Build
-        run: hatch build
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        - uses: actions/checkout@v4
+          with:
+            token: ${{ secrets.GITHUB_TOKEN }}
+        - uses: actions/setup-python@v5
+          with:
+            python-version: '3.x'
+            cache: 'pip'
+        - name: Install Hatch
+          run: |
+            python -m pip install --upgrade pip
+            pip install hatch
+        - name: Bump patch version
+          id: bump
+          run: |
+            old_version=$(hatch version)
+            hatch version patch
+            new_version=$(hatch version)
+            echo "new_version=$new_version" >> "$GITHUB_OUTPUT"
+        - name: Commit and tag
+          env:
+            NEW_VERSION: ${{ steps.bump.outputs.new_version }}
+          run: |
+            git config user.name github-actions
+            git config user.email github-actions@github.com
+            git commit -am "chore: bump version to $NEW_VERSION"
+            git tag "v$NEW_VERSION"
+            git push --follow-tags
+        - name: Build
+          run: hatch build
+        - name: Publish to PyPI
+          uses: pypa/gh-action-pypi-publish@release/v1
+          with:
+            user: __token__
+            password: ${{ secrets.PYPI_API_TOKEN }}
 

--- a/README-pypi.md
+++ b/README-pypi.md
@@ -8,7 +8,9 @@ assigner aware of long vowels and accent marks, and an IPA canonicalizer that
 together provide an experimental `furlang2p` command-line tool. The normalizer
 spells out numbers up to 999 999 999 999 and can expand units, abbreviations and
 acronyms, with rules loaded from JSON or YAML files, while the tokenizer can
-skip sentence splits after configurable abbreviations.
+skip sentence splits after configurable abbreviations.  The CLI also offers
+subcommands to normalize text, output phoneme sequences and batch phonemize
+metadata CSV files.
 
 ## Installation
 
@@ -42,8 +44,34 @@ furlang2p ipa --sep '|' _ "ìsule" __
 # -> _|ˈizule|__
 ```
 
-Other subcommands (`normalize`, `g2p`, `phonemize-csv`) are stubs and currently
-raise `NotImplementedError`.
+Other available subcommands:
+
+- Normalize and expand numbers/abbreviations:
+
+  ```bash
+  furlang2p normalize "CJASE 1964 kg"
+  # -> cjase mil nûfcent e sessantecuatri chilogram
+  ```
+
+- Convert a phrase to phonemes:
+
+  ```bash
+  furlang2p g2p "Cjase"
+  # -> ˈc a z e
+  ```
+
+- Phonemize a metadata CSV:
+
+  ```bash
+  furlang2p phonemize-csv --in metadata.csv --out out.csv
+  ```
+
+The repository also ships a convenience script providing the same batch
+conversion:
+
+```bash
+python scripts/generate_phonemes.py --in metadata.csv --out out.csv
+```
 
 ## Python usage
 

--- a/README-pypi.md
+++ b/README-pypi.md
@@ -2,12 +2,13 @@
 
 Utilities for converting Friulian (Furlan) text to phonemes. The package
 includes a tiny gold lexicon with variant transcriptions, a dialect-aware
-letter‑to‑sound rule engine, a configurable normalization routine and a
-sentence/word tokenizer that together provide an experimental `furlang2p`
-command-line tool. The normalizer spells out numbers up to 999 999 999 999 and
-can expand units, abbreviations and acronyms, with rules loaded from JSON or
-YAML files, while the tokenizer can skip sentence splits after configurable
-abbreviations.
+letter‑to‑sound rule engine, a configurable normalization routine, a
+sentence/word tokenizer, a syllabifier with basic phonotactics, a stress
+assigner aware of long vowels and accent marks, and an IPA canonicalizer that
+together provide an experimental `furlang2p` command-line tool. The normalizer
+spells out numbers up to 999 999 999 999 and can expand units, abbreviations and
+acronyms, with rules loaded from JSON or YAML files, while the tokenizer can
+skip sentence splits after configurable abbreviations.
 
 ## Installation
 

--- a/README-pypi.md
+++ b/README-pypi.md
@@ -1,11 +1,12 @@
 # FurlanG2P
 
 Utilities for converting Friulian (Furlan) text to phonemes. The package
-includes a tiny gold lexicon, a rule-based engine and a configurable
-normalization routine that together provide an experimental `furlang2p`
-command-line tool. The normalizer spells out numbers up to 999 999 999 999 and
-can expand units, abbreviations and acronyms, with rules loaded from JSON or
-YAML files.
+includes a tiny gold lexicon, a rule-based engine, a configurable normalization
+routine and a sentence/word tokenizer that together provide an experimental
+`furlang2p` command-line tool. The normalizer spells out numbers up to
+999 999 999 999 and can expand units, abbreviations and acronyms, with rules
+loaded from JSON or YAML files, while the tokenizer can skip sentence splits
+after configurable abbreviations.
 
 ## Installation
 

--- a/README-pypi.md
+++ b/README-pypi.md
@@ -3,8 +3,9 @@
 Utilities for converting Friulian (Furlan) text to phonemes. The package
 includes a tiny gold lexicon, a rule-based engine and a configurable
 normalization routine that together provide an experimental `furlang2p`
-command-line tool. The normalizer can expand numbers, units, abbreviations and
-acronyms, with rules loaded from JSON or YAML files.
+command-line tool. The normalizer spells out numbers up to 999 999 999 999 and
+can expand units, abbreviations and acronyms, with rules loaded from JSON or
+YAML files.
 
 ## Installation
 

--- a/README-pypi.md
+++ b/README-pypi.md
@@ -1,8 +1,10 @@
 # FurlanG2P
 
 Utilities for converting Friulian (Furlan) text to phonemes. The package
-includes a tiny gold lexicon and a rule-based engine that together provide an
-experimental `furlang2p` command-line tool.
+includes a tiny gold lexicon, a rule-based engine and a configurable
+normalization routine that together provide an experimental `furlang2p`
+command-line tool. The normalizer can expand numbers, units, abbreviations and
+acronyms, with rules loaded from JSON or YAML files.
 
 ## Installation
 

--- a/README-pypi.md
+++ b/README-pypi.md
@@ -73,6 +73,9 @@ conversion:
 python scripts/generate_phonemes.py --in metadata.csv --out out.csv
 ```
 
+All subcommands validate inputs and emit clear error messages for missing
+files or conflicting arguments.
+
 ## Python usage
 
 The same components can be invoked programmatically:

--- a/README-pypi.md
+++ b/README-pypi.md
@@ -78,20 +78,30 @@ files or conflicting arguments.
 
 ## Python usage
 
-The same components can be invoked programmatically:
+Invoke the full pipeline programmatically:
 
 ```python
-from furlan_g2p.g2p.lexicon import Lexicon
-from furlan_g2p.g2p.rule_engine import RuleEngine
-from furlan_g2p.phonology import canonicalize_ipa
+from furlan_g2p.services import PipelineService
 
-lex = Lexicon.load_seed()
-rules = RuleEngine()
-word = "glaç"
-ipa = lex.get(word) or canonicalize_ipa(rules.convert(word))
-print(ipa)
-# -> ˈglatʃ
+pipe = PipelineService()
+norm, phonemes = pipe.process_text("Cjase")
+print(norm)                   # cjase
+print(" ".join(phonemes))     # ˈc a z e
 ```
+
+Normalisation rules can be customised via external JSON or YAML files:
+
+```python
+from furlan_g2p.config import load_normalizer_config
+from furlan_g2p.normalization import Normalizer
+
+cfg = load_normalizer_config("norm_rules.yml")
+print(Normalizer(cfg).normalize("1964 kg"))
+# -> mil nûfcent e sessantecuatri chilogram
+```
+
+Lower-level components such as the lexicon and rule engine remain available for
+fine-grained control.
 
 ## Project links
 

--- a/README-pypi.md
+++ b/README-pypi.md
@@ -1,12 +1,13 @@
 # FurlanG2P
 
 Utilities for converting Friulian (Furlan) text to phonemes. The package
-includes a tiny gold lexicon, a rule-based engine, a configurable normalization
-routine and a sentence/word tokenizer that together provide an experimental
-`furlang2p` command-line tool. The normalizer spells out numbers up to
-999 999 999 999 and can expand units, abbreviations and acronyms, with rules
-loaded from JSON or YAML files, while the tokenizer can skip sentence splits
-after configurable abbreviations.
+includes a tiny gold lexicon with variant transcriptions, a dialect-aware
+letter‑to‑sound rule engine, a configurable normalization routine and a
+sentence/word tokenizer that together provide an experimental `furlang2p`
+command-line tool. The normalizer spells out numbers up to 999 999 999 999 and
+can expand units, abbreviations and acronyms, with rules loaded from JSON or
+YAML files, while the tokenizer can skip sentence splits after configurable
+abbreviations.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # FurlanG2P
 
-Tools and library code for converting Friulian (Furlan) text to phonemes.
-The repository includes a small gold lexicon, a rule-based orthography to IPA
-converter, a configurable normalization routine, a sentence/word tokenizer with
-abbreviation handling, and simple syllabifier and stress assigner. The
-normalizer can spell out numbers up to 999 999 999 999 and expand units,
-abbreviations and acronyms, with rules loadable from JSON or YAML files. These
-pieces back an experimental `furlang2p` CLI. Other parts of the pipeline—full
-G2P services and several CLI commands—remain placeholders that raise
-`NotImplementedError`.
+Tools and library code for converting Friulian (Furlan) text to phonemes.  The
+repository includes a small gold lexicon with IPA variants, a dialect-aware
+letter‑to‑sound rule engine backed by a curated phoneme inventory, a
+configurable normalization routine, a sentence/word tokenizer with abbreviation
+handling, and simple syllabifier and stress assigner. The normalizer can spell
+out numbers up to 999 999 999 999 and expand units, abbreviations and acronyms,
+with rules loadable from JSON or YAML files. These pieces back an experimental
+`furlang2p` CLI. Other parts of the pipeline—full G2P services and several CLI
+commands—remain placeholders that raise `NotImplementedError`.
 
 ## Project layout
 

--- a/README.md
+++ b/README.md
@@ -162,6 +162,10 @@ mypy .
 pytest
 ```
 
+The test suite exercises the CLI, covers regression "golden" sets under
+`tests/data/` and performs end‑to‑end checks of the full pipeline.  New
+features should extend these tests to guard against behavioural regressions.
+
 ## References
 
 FurlanG2P follows published descriptions of Friulian orthography and

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 Tools and library code for converting Friulian (Furlan) text to phonemes.
 The repository includes a small gold lexicon, a rule-based orthography to IPA
 converter, a configurable normalization routine, syllabifier and stress
-assigner. The normalizer now supports basic expansion of numbers, units,
-abbreviations and acronyms, and its rules can be loaded from JSON or YAML
+assigner. The normalizer can spell out numbers up to 999 999 999 999 and expand
+units, abbreviations and acronyms, with rules loadable from JSON or YAML
 files. These pieces back an experimental `furlang2p` CLI. Other parts of the
 pipeline—tokenisation, full G2P services and several CLI commands—remain
 placeholders that raise `NotImplementedError`.
@@ -88,8 +88,8 @@ from furlan_g2p.normalization.normalizer import Normalizer
 
 cfg = load_normalizer_config("norm_rules.yml")
 norm = Normalizer(cfg)
-print(norm.normalize("10 kg"))
-# -> dîs chilogram
+print(norm.normalize("1964 kg"))
+# -> mil nûfcent e sessantecuatri chilogram
 ```
 
 ## Building

--- a/README.md
+++ b/README.md
@@ -135,6 +135,24 @@ print(tok.split_sentences("Al è rivât il Sig. Bepo. O ven?"))
 # -> ['Al è rivât il Sig. Bepo.', 'O ven?']
 ```
 
+### Pipeline service
+
+For end‑to‑end processing, instantiate :class:`PipelineService` to chain
+normalisation, tokenisation, grapheme‑to‑phoneme conversion and basic
+phonology:
+
+```python
+from furlan_g2p.services import PipelineService
+
+pipe = PipelineService()
+norm, phonemes = pipe.process_text("Cjase")
+print(norm)      # cjase
+print(phonemes)  # ['ˈc', 'a', 'z', 'e']
+```
+
+The same service exposes ``process_csv`` to phonemise LJSpeech‑style metadata
+files.
+
 ## Building
 
 The project uses [Hatchling](https://hatch.pypa.io/) as build backend.
@@ -165,6 +183,14 @@ pytest
 The test suite exercises the CLI, covers regression "golden" sets under
 `tests/data/` and performs end‑to‑end checks of the full pipeline.  New
 features should extend these tests to guard against behavioural regressions.
+
+## CI/CD
+
+Continuous integration and release workflows live under
+``.github/workflows/``.  ``ci.yml`` runs formatting, type checks and tests on
+every push and pull request, while ``release.yml`` bumps the package version,
+builds distributions with Hatch and publishes them to PyPI when changes land on
+``main``.
 
 ## References
 

--- a/README.md
+++ b/README.md
@@ -2,18 +2,20 @@
 
 Tools and library code for converting Friulian (Furlan) text to phonemes.
 The repository includes a small gold lexicon, a rule-based orthography to IPA
-converter, a configurable normalization routine, syllabifier and stress
-assigner. The normalizer can spell out numbers up to 999 999 999 999 and expand
-units, abbreviations and acronyms, with rules loadable from JSON or YAML
-files. These pieces back an experimental `furlang2p` CLI. Other parts of the
-pipeline—tokenisation, full G2P services and several CLI commands—remain
-placeholders that raise `NotImplementedError`.
+converter, a configurable normalization routine, a sentence/word tokenizer with
+abbreviation handling, and simple syllabifier and stress assigner. The
+normalizer can spell out numbers up to 999 999 999 999 and expand units,
+abbreviations and acronyms, with rules loadable from JSON or YAML files. These
+pieces back an experimental `furlang2p` CLI. Other parts of the pipeline—full
+G2P services and several CLI commands—remain placeholders that raise
+`NotImplementedError`.
 
 ## Project layout
 
 - `src/furlan_g2p/cli/` – command-line interface entry points.
 - `src/furlan_g2p/g2p/` – lexicon, rules and simple converters.
 - `src/furlan_g2p/normalization/` – configurable text normalizer.
+- `src/furlan_g2p/tokenization/` – sentence and word tokenizer.
 - `src/furlan_g2p/phonology/` – canonical IPA helpers, syllabifier and stress
   assigner.
 - `examples/` – sample inputs and outputs.
@@ -90,6 +92,22 @@ cfg = load_normalizer_config("norm_rules.yml")
 norm = Normalizer(cfg)
 print(norm.normalize("1964 kg"))
 # -> mil nûfcent e sessantecuatri chilogram
+```
+
+### Loading tokenizer configuration
+
+Sentence splitting can be customised by listing abbreviations that should not
+end a sentence.  The list is read from JSON or YAML into a
+``TokenizerConfig``:
+
+```python
+from furlan_g2p.config import load_tokenizer_config
+from furlan_g2p.tokenization import Tokenizer
+
+cfg = load_tokenizer_config("tok_rules.yml")  # {"abbrev_no_split": ["sig"]}
+tok = Tokenizer(cfg)
+print(tok.split_sentences("Al è rivât il Sig. Bepo. O ven?"))
+# -> ['Al è rivât il Sig. Bepo.', 'O ven?']
 ```
 
 ## Building

--- a/README.md
+++ b/README.md
@@ -4,11 +4,13 @@ Tools and library code for converting Friulian (Furlan) text to phonemes.  The
 repository includes a small gold lexicon with IPA variants, a dialect-aware
 letter‑to‑sound rule engine backed by a curated phoneme inventory, a
 configurable normalization routine, a sentence/word tokenizer with abbreviation
-handling, and simple syllabifier and stress assigner. The normalizer can spell
-out numbers up to 999 999 999 999 and expand units, abbreviations and acronyms,
-with rules loadable from JSON or YAML files. These pieces back an experimental
-`furlang2p` CLI. Other parts of the pipeline—full G2P services and several CLI
-commands—remain placeholders that raise `NotImplementedError`.
+handling, a syllabifier with basic Friulian phonotactics, a stress assigner that
+accounts for long vowels and marked accents, and an IPA canonicalizer. The
+normalizer can spell out numbers up to 999 999 999 999 and expand units,
+abbreviations and acronyms, with rules loadable from JSON or YAML files. These
+pieces back an experimental `furlang2p` CLI. Other parts of the pipeline—full
+G2P services and several CLI commands—remain placeholders that raise
+`NotImplementedError`.
 
 ## Project layout
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,8 @@ handling, a syllabifier with basic Friulian phonotactics, a stress assigner that
 accounts for long vowels and marked accents, and an IPA canonicalizer. The
 normalizer can spell out numbers up to 999 999 999 999 and expand units,
 abbreviations and acronyms, with rules loadable from JSON or YAML files. These
-pieces back an experimental `furlang2p` CLI. Other parts of the pipeline—full
-G2P services and several CLI commands—remain placeholders that raise
-`NotImplementedError`.
+pieces back an experimental `furlang2p` CLI with subcommands for normalization,
+G2P conversion and batch phonemization of CSV files.
 
 ## Project layout
 
@@ -22,7 +21,7 @@ G2P services and several CLI commands—remain placeholders that raise
   assigner.
 - `examples/` – sample inputs and outputs.
 - `docs/` – supplementary documentation and bibliography.
-- `scripts/` – helper scripts (future automation).
+- `scripts/` – helper scripts (e.g. `generate_phonemes.py` for CSV batch runs).
 - `tests/` – minimal tests covering the implemented pieces and stubs.
 
 ## Quick local run (how to launch the CLI and test phrases)
@@ -77,9 +76,33 @@ G2P services and several CLI commands—remain placeholders that raise
      # -> _|ˈizule|__
      ```
 
+   Other implemented subcommands:
+
+   - Normalize text and expand numbers/abbreviations:
+     ```bash
+     furlang2p normalize "CJASE 1964 kg"
+     # -> cjase mil nûfcent e sessantecuatri chilogram
+     ```
+
+   - Convert text to a phoneme sequence:
+     ```bash
+     furlang2p g2p "Cjase"
+     # -> ˈc a z e
+     ```
+
+   - Phonemize an LJSpeech-style CSV:
+     ```bash
+     furlang2p phonemize-csv --in metadata.csv --out out.csv
+     ```
+
+   The same batch operation is available as a standalone script:
+
+   ```bash
+   python scripts/generate_phonemes.py --in metadata.csv --out out.csv
+   ```
+
    Notes:
    - Quotes around the phrase are recommended to preserve spacing and punctuation.
-   - The CLI is experimental; some commands (`normalize`, `g2p`, `phonemize-csv`) are stubs that raise `NotImplementedError`.
 
 ### Loading normalizer configuration
 

--- a/README.md
+++ b/README.md
@@ -2,16 +2,18 @@
 
 Tools and library code for converting Friulian (Furlan) text to phonemes.
 The repository includes a small gold lexicon, a rule-based orthography to IPA
-converter, a normalization routine, syllabifier and stress assigner. These
-pieces back an experimental `furlang2p` CLI. Other parts of the pipeline—
-tokenisation, full G2P services and several CLI commands—remain placeholders
-that raise `NotImplementedError`.
+converter, a configurable normalization routine, syllabifier and stress
+assigner. The normalizer now supports basic expansion of numbers, units,
+abbreviations and acronyms, and its rules can be loaded from JSON or YAML
+files. These pieces back an experimental `furlang2p` CLI. Other parts of the
+pipeline—tokenisation, full G2P services and several CLI commands—remain
+placeholders that raise `NotImplementedError`.
 
 ## Project layout
 
 - `src/furlan_g2p/cli/` – command-line interface entry points.
 - `src/furlan_g2p/g2p/` – lexicon, rules and simple converters.
-- `src/furlan_g2p/normalization/` – experimental text normalizer.
+- `src/furlan_g2p/normalization/` – configurable text normalizer.
 - `src/furlan_g2p/phonology/` – canonical IPA helpers, syllabifier and stress
   assigner.
 - `examples/` – sample inputs and outputs.
@@ -74,6 +76,21 @@ that raise `NotImplementedError`.
    Notes:
    - Quotes around the phrase are recommended to preserve spacing and punctuation.
    - The CLI is experimental; some commands (`normalize`, `g2p`, `phonemize-csv`) are stubs that raise `NotImplementedError`.
+
+### Loading normalizer configuration
+
+Normalization rules can be customised via external JSON or YAML files. A helper
+utility loads the file into a :class:`NormalizerConfig` dataclass:
+
+```python
+from furlan_g2p.config import load_normalizer_config
+from furlan_g2p.normalization.normalizer import Normalizer
+
+cfg = load_normalizer_config("norm_rules.yml")
+norm = Normalizer(cfg)
+print(norm.normalize("10 kg"))
+# -> dîs chilogram
+```
 
 ## Building
 

--- a/docs/references.md
+++ b/docs/references.md
@@ -40,3 +40,7 @@
 
 - Wiktionary. *Category: Friulian terms with IPA pronunciation*. [https://en.wiktionary.org/wiki/Category:Friulian_terms_with_IPA_pronunciation](https://en.wiktionary.org/wiki/Category:Friulian_terms_with_IPA_pronunciation) ([archive](https://web.archive.org/web/*/https://en.wiktionary.org/wiki/Category:Friulian_terms_with_IPA_pronunciation)).
 
+## Numbers and abbreviations
+
+- Wiktionary. *Category: Friulian cardinal numbers*. [https://en.wiktionary.org/wiki/Category:Friulian_cardinal_numbers](https://en.wiktionary.org/wiki/Category:Friulian_cardinal_numbers) ([archive](https://web.archive.org/web/*/https://en.wiktionary.org/wiki/Category:Friulian_cardinal_numbers)).
+

--- a/docs/references.md
+++ b/docs/references.md
@@ -31,6 +31,8 @@
 - pît — [Wiktionary](https://en.wiktionary.org/wiki/p%C3%AEt) ([archive](https://web.archive.org/web/*/https://en.wiktionary.org/wiki/p%C3%AEt)).
 - mûr — [Wiktionary](https://en.wiktionary.org/wiki/m%C3%BBr) ([archive](https://web.archive.org/web/*/https://en.wiktionary.org/wiki/m%C3%BBr)).
 - côr — [Wiktionary](https://en.wiktionary.org/wiki/c%C3%B4r) ([archive](https://web.archive.org/web/*/https://en.wiktionary.org/wiki/c%C3%B4r)).
+- gjat — [Wiktionary](https://en.wiktionary.org/wiki/gjat) ([archive](https://web.archive.org/web/*/https://en.wiktionary.org/wiki/gjat)).
+- zûc — [Wiktionary](https://en.wiktionary.org/wiki/z%C3%BBc) ([archive](https://web.archive.org/web/*/https://en.wiktionary.org/wiki/z%C3%BBc)).
 - cjase — [Wiktionary](https://en.wiktionary.org/wiki/cjase) ([archive](https://web.archive.org/web/*/https://en.wiktionary.org/wiki/cjase)).
 - cjandele — [Wiktionary](https://en.wiktionary.org/wiki/cjandele) ([archive](https://web.archive.org/web/*/https://en.wiktionary.org/wiki/cjandele)).
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,57 @@
+# Usage guide
+
+This guide shows how to run the library components and customise their behaviour.
+
+## Pipeline API
+
+```python
+from furlan_g2p.services import PipelineService
+
+pipe = PipelineService()
+norm, phonemes = pipe.process_text("Cjase")
+print(norm)      # cjase
+print(phonemes)  # ['ˈc', 'a', 'z', 'e']
+```
+
+Call ``process_csv`` to phonemise an LJSpeech ``metadata.csv`` file:
+
+```python
+pipe.process_csv("metadata.csv", "out.csv")
+```
+
+## Normalisation rules
+
+Load replacement maps and pause markers from JSON or YAML files and feed them to
+:class:`Normalizer`:
+
+```python
+from furlan_g2p.config import load_normalizer_config
+from furlan_g2p.normalization import Normalizer
+
+cfg = load_normalizer_config("norm_rules.yml")
+print(Normalizer(cfg).normalize("1964 kg"))
+# -> mil nûfcent e sessantecuatri chilogram
+```
+
+## Tokenizer configuration
+
+Custom abbreviations that should not end a sentence can be stored externally:
+
+```python
+from furlan_g2p.config import load_tokenizer_config
+from furlan_g2p.tokenization import Tokenizer
+
+cfg = load_tokenizer_config("tok_rules.yml")
+print(Tokenizer(cfg).split_sentences("Al è rivât il Sig. Bepo. O ven?"))
+# -> ['Al è rivât il Sig. Bepo.', 'O ven?']
+```
+
+## CLI
+
+The ``furlang2p`` command groups several subcommands:
+
+```bash
+furlang2p normalize "CJASE 1964 kg"      # text normalisation
+furlang2p g2p "Cjase"                    # phoneme sequence
+furlang2p phonemize-csv --in metadata.csv --out out.csv
+```

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,8 +1,8 @@
 Examples
+========
 
-This folder will contain runnable examples once the core logic is implemented.
-For now, see the CLI help:
+Small scripts demonstrating the public API. Run them after installing the
+package or by setting ``PYTHONPATH=src`` in the repository root.
 
-```
-furlang2p --help
-```
+- ``pipeline_example.py`` – normalises and phonemises a short phrase using the
+  :class:`PipelineService`.

--- a/examples/pipeline_example.py
+++ b/examples/pipeline_example.py
@@ -1,0 +1,17 @@
+"""Minimal PipelineService demo."""
+
+from __future__ import annotations
+
+from furlan_g2p.services import PipelineService
+
+
+def main() -> None:
+    """Run a short text through the full pipeline and print results."""
+    pipe = PipelineService()
+    norm, phonemes = pipe.process_text("Cjase 1964 kg")
+    print(norm)
+    print(" ".join(phonemes))
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dev = [
   "pytest>=8.0.0",
   "pytest-cov>=4.1.0",
   "hypothesis>=6.0.0",
+  "pyyaml>=6.0",
   "mypy>=1.10.0",
   "ruff>=0.5.0",
   "black>=24.4.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "furlang2p"
 dynamic = ["version"]
-description = "FurlanG2P: a scalable, library-first G2P and text normalization toolkit (skeleton)."
+description = "Friulian text normalization, tokenization, G2P conversion and phonology with a CLI and pipeline service."
 readme = { file = "README-pypi.md", content-type = "text/markdown" }
 requires-python = ">=3.10"
 license = { text = "MIT" }

--- a/scripts/generate_phonemes.py
+++ b/scripts/generate_phonemes.py
@@ -1,15 +1,33 @@
 #!/usr/bin/env python3
-"""Example script entry (skeleton)."""
+"""Batch phonemize a metadata CSV file using :class:`PipelineService`."""
 
 from __future__ import annotations
+
+import argparse
+import sys
 
 from furlan_g2p.services.pipeline import PipelineService
 
 
 def main() -> None:
-    """Run the example pipeline (unimplemented)."""
-    _ = PipelineService()
-    raise NotImplementedError("Example script is not implemented yet.")
+    """Phonemize an input CSV and write the result to ``--out``.
+
+    The input file is expected to contain LJSpeech-style rows with at least an
+    identifier and the text to phonemize separated by ``--delim``.
+    """
+
+    parser = argparse.ArgumentParser(description="Batch phonemize a metadata CSV")
+    parser.add_argument("--in", dest="inp", required=True, help="Input metadata CSV")
+    parser.add_argument("--out", dest="out", required=True, help="Output CSV path")
+    parser.add_argument("--delim", dest="delim", default="|", help="CSV delimiter", metavar="D")
+    args = parser.parse_args()
+
+    service = PipelineService()
+    try:
+        service.process_csv(args.inp, args.out, delimiter=args.delim)
+    except FileNotFoundError as e:
+        print(f"Missing file: {e.filename}", file=sys.stderr)
+        raise SystemExit(1) from e
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/src/furlan_g2p/config/__init__.py
+++ b/src/furlan_g2p/config/__init__.py
@@ -6,7 +6,7 @@ import json
 from pathlib import Path
 from typing import Any
 
-from .schemas import NormalizerConfig
+from .schemas import NormalizerConfig, TokenizerConfig
 
 try:  # pragma: no cover - optional dependency
     import yaml  # type: ignore[import-untyped]
@@ -14,28 +14,7 @@ except Exception:  # pragma: no cover - optional dependency
     yaml = None
 
 
-def load_normalizer_config(path: str | Path) -> NormalizerConfig:
-    """Load a :class:`NormalizerConfig` from a JSON or YAML file.
-
-    Parameters
-    ----------
-    path:
-        Path to a configuration file.  Supported formats are JSON, ``.yml`` and
-        ``.yaml``.  YAML loading requires the optional :mod:`pyyaml` dependency.
-
-    Returns
-    -------
-    NormalizerConfig
-        Parsed configuration dataclass.
-
-    Raises
-    ------
-    ValueError
-        If the file extension is not recognised.
-    ImportError
-        If a YAML file is provided but :mod:`pyyaml` is not installed.
-    """
-
+def _load_mapping(path: str | Path) -> dict[str, Any]:
     p = Path(path)
     text = p.read_text(encoding="utf-8")
     if p.suffix.lower() == ".json":
@@ -48,7 +27,26 @@ def load_normalizer_config(path: str | Path) -> NormalizerConfig:
         raise ValueError(f"Unsupported config format: {p.suffix}")
     if not isinstance(data, dict):  # pragma: no cover - defensive
         raise TypeError("Configuration file must contain a mapping")
+    return data
+
+
+def load_normalizer_config(path: str | Path) -> NormalizerConfig:
+    """Load a :class:`NormalizerConfig` from a JSON or YAML file."""
+
+    data = _load_mapping(path)
     return NormalizerConfig(**data)
 
 
-__all__ = ["load_normalizer_config", "NormalizerConfig"]
+def load_tokenizer_config(path: str | Path) -> TokenizerConfig:
+    """Load a :class:`TokenizerConfig` from a JSON or YAML file."""
+
+    data = _load_mapping(path)
+    return TokenizerConfig(**data)
+
+
+__all__ = [
+    "load_normalizer_config",
+    "load_tokenizer_config",
+    "NormalizerConfig",
+    "TokenizerConfig",
+]

--- a/src/furlan_g2p/config/__init__.py
+++ b/src/furlan_g2p/config/__init__.py
@@ -1,5 +1,54 @@
-"""Config data structures and loading utilities (skeleton)."""
+"""Config data structures and loading utilities."""
 
 from __future__ import annotations
 
-__all__: list[str] = []
+import json
+from pathlib import Path
+from typing import Any
+
+from .schemas import NormalizerConfig
+
+try:  # pragma: no cover - optional dependency
+    import yaml  # type: ignore[import-untyped]
+except Exception:  # pragma: no cover - optional dependency
+    yaml = None
+
+
+def load_normalizer_config(path: str | Path) -> NormalizerConfig:
+    """Load a :class:`NormalizerConfig` from a JSON or YAML file.
+
+    Parameters
+    ----------
+    path:
+        Path to a configuration file.  Supported formats are JSON, ``.yml`` and
+        ``.yaml``.  YAML loading requires the optional :mod:`pyyaml` dependency.
+
+    Returns
+    -------
+    NormalizerConfig
+        Parsed configuration dataclass.
+
+    Raises
+    ------
+    ValueError
+        If the file extension is not recognised.
+    ImportError
+        If a YAML file is provided but :mod:`pyyaml` is not installed.
+    """
+
+    p = Path(path)
+    text = p.read_text(encoding="utf-8")
+    if p.suffix.lower() == ".json":
+        data: dict[str, Any] = json.loads(text)
+    elif p.suffix.lower() in {".yml", ".yaml"}:
+        if yaml is None:
+            raise ImportError("pyyaml is required for YAML config files")
+        data = yaml.safe_load(text)
+    else:  # pragma: no cover - defensive
+        raise ValueError(f"Unsupported config format: {p.suffix}")
+    if not isinstance(data, dict):  # pragma: no cover - defensive
+        raise TypeError("Configuration file must contain a mapping")
+    return NormalizerConfig(**data)
+
+
+__all__ = ["load_normalizer_config", "NormalizerConfig"]

--- a/src/furlan_g2p/config/schemas.py
+++ b/src/furlan_g2p/config/schemas.py
@@ -11,6 +11,8 @@ class NormalizerConfig:
 
     units_map: dict[str, str] = field(default_factory=dict)
     acronyms_map: dict[str, str] = field(default_factory=dict)
+    abbreviations_map: dict[str, str] = field(default_factory=dict)
+    numbers_map: dict[str, str] = field(default_factory=dict)
     ordinal_map: dict[str, str] = field(default_factory=dict)
     pause_short: str = "_"
     pause_long: str = "__"

--- a/src/furlan_g2p/config/schemas.py
+++ b/src/furlan_g2p/config/schemas.py
@@ -3,15 +3,19 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import Final
+
+_DEFAULT_UNITS: Final[dict[str, str]] = {"kg": "chilogram"}
+_DEFAULT_ABBREVIATIONS: Final[dict[str, str]] = {"sig.": "siôr"}
 
 
 @dataclass(slots=True)
 class NormalizerConfig:
     """Configuration for normalization rules."""
 
-    units_map: dict[str, str] = field(default_factory=dict)
+    units_map: dict[str, str] = field(default_factory=lambda: dict(_DEFAULT_UNITS))
     acronyms_map: dict[str, str] = field(default_factory=dict)
-    abbreviations_map: dict[str, str] = field(default_factory=dict)
+    abbreviations_map: dict[str, str] = field(default_factory=lambda: dict(_DEFAULT_ABBREVIATIONS))
     numbers_map: dict[str, str] = field(default_factory=dict)
     ordinal_map: dict[str, str] = field(default_factory=dict)
     pause_short: str = "_"

--- a/src/furlan_g2p/data/seed_lexicon.tsv
+++ b/src/furlan_g2p/data/seed_lexicon.tsv
@@ -19,3 +19,5 @@ mûr	muːr	[]	https://en.wiktionary.org/wiki/m%C3%BBr
 côr	kɔːr	[]	https://en.wiktionary.org/wiki/c%C3%B4r
 cjase	ˈcaze	[]	https://en.wiktionary.org/wiki/cjase
 cjandele	caɲˈdɛle	[]	https://en.wiktionary.org/wiki/cjandele
+gjat	ɟat	["dʒat"]	https://en.wiktionary.org/wiki/gjat
+zûc	dzuːk	["tsuːk"]	https://en.wiktionary.org/wiki/z%C3%BBc

--- a/src/furlan_g2p/normalization/normalizer.py
+++ b/src/furlan_g2p/normalization/normalizer.py
@@ -12,20 +12,119 @@ from ..core.interfaces import INormalizer
 
 _APOSTROPHES_RE: Final = re.compile("[\u2019\u2018\u02bc]")
 
-# Default Friulian cardinals used if no override is provided.
-_DEFAULT_NUMBERS: Final[dict[str, str]] = {
-    "0": "zero",
-    "1": "un",
-    "2": "doi",
-    "3": "trê",
-    "4": "cuatri",
-    "5": "cinc",
-    "6": "sîs",
-    "7": "siet",
-    "8": "vot",
-    "9": "nûf",
-    "10": "dîs",
+# ---------------------------------------------------------------------------
+# Number to words conversion (0–999 999 999 999)
+# ---------------------------------------------------------------------------
+
+_CARD_0_19: Final[dict[int, str]] = {
+    0: "zeru",
+    1: "un",
+    2: "doi",
+    3: "trê",
+    4: "cuatri",
+    5: "cinc",
+    6: "sîs",
+    7: "siet",
+    8: "vot",
+    9: "nûf",
+    10: "dîs",
+    11: "undis",
+    12: "dodis",
+    13: "tredis",
+    14: "cutuardis",
+    15: "cuindis",
+    16: "sedis",
+    17: "disesiet",
+    18: "disevot",
+    19: "disenûf",
 }
+
+_TENS: Final[dict[int, str]] = {
+    20: "vincj",
+    30: "trente",
+    40: "cuarante",
+    50: "cincuante",
+    60: "sessante",
+    70: "setante",
+    80: "otante",
+    90: "nonante",
+}
+
+_UNITS: Final = [
+    (1_000_000_000, "miliart", "miliarts"),
+    (1_000_000, "milion", "milions"),
+    (1000, "mil", "mil"),
+]
+
+
+def _card_u99(n: int) -> str:
+    if n < 20:
+        return _CARD_0_19[n]
+    tens, unit = divmod(n, 10)
+    return _TENS[tens * 10] if unit == 0 else f"{_TENS[tens * 10]}{_CARD_0_19[unit]}"
+
+
+def _card_u999(n: int) -> str:
+    if n < 100:
+        return _card_u99(n)
+    hundreds, rest = divmod(n, 100)
+    cent_part = "cent" if hundreds == 1 else f"{_CARD_0_19[hundreds]}cent"
+    if rest == 0:
+        return cent_part
+    if rest < 100:
+        return f"{cent_part} e {_card_u99(rest)}"
+    return f"{cent_part} {_card_u999(rest)}"
+
+
+def number_to_words_fr(n: int) -> str:
+    """Convert an integer to Friulian words.
+
+    Parameters
+    ----------
+    n:
+        Number between 0 and 999 999 999 999.
+
+    Returns
+    -------
+    str
+        The number spelled out in Friulian. Out-of-range values are returned as
+        their decimal string.
+
+    Examples
+    --------
+    >>> number_to_words_fr(2004)
+    'doi mil e cuatri'
+    >>> number_to_words_fr(1964)
+    'mil nûfcent e sessantecuatri'
+    """
+
+    if not 0 <= n <= 999_999_999_999:
+        return str(n)
+    if n < 1000:
+        return _card_u999(n)
+    parts: list[str] = []
+    remainder = n
+    for value, singular, plural in _UNITS:
+        qty, remainder = divmod(remainder, value)
+        if qty == 0:
+            continue
+        if value == 1000:
+            part = "mil" if qty == 1 else f"{_card_u999(qty)} mil"
+        else:
+            base = "un" if qty == 1 else _card_u999(qty)
+            label = singular if qty == 1 else plural
+            part = f"{base} {label}"
+        parts.append(part)
+    if remainder:
+        rem_words = _card_u999(remainder)
+        if remainder < 100:
+            return f"{' '.join(parts)} e {rem_words}"
+        parts.append(rem_words)
+    return " ".join(parts)
+
+
+# Default cardinals allow overriding specific forms in configuration.
+_DEFAULT_NUMBERS: Final[dict[str, str]] = {str(k): v for k, v in _CARD_0_19.items()}
 
 
 class Normalizer(INormalizer):
@@ -33,12 +132,13 @@ class Normalizer(INormalizer):
 
     The normalizer lowercases text, converts curly apostrophes to straight ones,
     maps punctuation to pause markers and replaces numbers, abbreviations,
-    acronyms and units according to :class:`NormalizerConfig`.
+    acronyms and units according to :class:`NormalizerConfig`. Numbers not
+    explicitly mapped are spelled out in Friulian up to 999 999 999 999.
 
     Examples
     --------
-    >>> Normalizer().normalize("10 kg, Sig.")
-    'dîs chilogram _ siôr'
+    >>> Normalizer().normalize("1964 kg, Sig.")
+    'mil nûfcent e sessantecuatri chilogram _ siôr'
     """
 
     def __init__(self, config: NormalizerConfig | None = None) -> None:
@@ -49,7 +149,10 @@ class Normalizer(INormalizer):
         token = self.config.abbreviations_map.get(token, token)
         token = self.config.acronyms_map.get(token, token)
         token = self.config.units_map.get(token, token)
-        token = self._numbers_map.get(token, token)
+        if token in self._numbers_map:
+            token = self._numbers_map[token]
+        elif re.fullmatch(r"\d{1,3}(?:\.\d{3})+|\d+", token):
+            token = number_to_words_fr(int(token.replace(".", "")))
         token = self.config.ordinal_map.get(token, token)
         return token
 

--- a/src/furlan_g2p/normalization/normalizer.py
+++ b/src/furlan_g2p/normalization/normalizer.py
@@ -3,26 +3,55 @@
 from __future__ import annotations
 
 import re
+import unicodedata
+from typing import Final
 
 from ..config.schemas import NormalizerConfig
 from ..core.exceptions import NormalizationError  # noqa: F401
 from ..core.interfaces import INormalizer
 
+_APOSTROPHES_RE: Final = re.compile("[\u2019\u2018\u02bc]")
+
+# Default Friulian cardinals used if no override is provided.
+_DEFAULT_NUMBERS: Final[dict[str, str]] = {
+    "0": "zero",
+    "1": "un",
+    "2": "doi",
+    "3": "trê",
+    "4": "cuatri",
+    "5": "cinc",
+    "6": "sîs",
+    "7": "siet",
+    "8": "vot",
+    "9": "nûf",
+    "10": "dîs",
+}
+
 
 class Normalizer(INormalizer):
-    """Simple text normalizer.
+    """Simple text normalizer with basic expansion rules.
 
-    The current implementation performs very lightweight normalization by
-    lowercasing the input and collapsing consecutive whitespace characters.
+    The normalizer lowercases text, converts curly apostrophes to straight ones,
+    maps punctuation to pause markers and replaces numbers, abbreviations,
+    acronyms and units according to :class:`NormalizerConfig`.
 
     Examples
     --------
-    >>> Normalizer().normalize("  Bêle  CJASE  ")
-    'bêle cjase'
+    >>> Normalizer().normalize("10 kg, Sig.")
+    'dîs chilogram _ siôr'
     """
 
     def __init__(self, config: NormalizerConfig | None = None) -> None:
         self.config = config or NormalizerConfig()
+        self._numbers_map = {**_DEFAULT_NUMBERS, **self.config.numbers_map}
+
+    def _replace_token(self, token: str) -> str:
+        token = self.config.abbreviations_map.get(token, token)
+        token = self.config.acronyms_map.get(token, token)
+        token = self.config.units_map.get(token, token)
+        token = self._numbers_map.get(token, token)
+        token = self.config.ordinal_map.get(token, token)
+        return token
 
     def normalize(self, text: str) -> str:
         """Normalize raw input text into a canonical, speakable form.
@@ -46,9 +75,19 @@ class Normalizer(INormalizer):
         if not isinstance(text, str):  # pragma: no cover - defensive programming
             raise NormalizationError("Input must be a string")
 
-        # Collapse whitespace and lowercase.
-        normalized = re.sub(r"\s+", " ", text.strip()).lower()
-        return normalized
+        s = unicodedata.normalize("NFC", text)
+        s = _APOSTROPHES_RE.sub("'", s)
+        s = re.sub(r"[,;:]", f" {self.config.pause_short} ", s)
+        s = re.sub(r"[.?!]", f" {self.config.pause_long} ", s)
+        tokens = [t for t in re.split(r"\s+", s.strip()) if t]
+        out_tokens: list[str] = []
+        for raw in tokens:
+            token = raw.lower()
+            if token in {self.config.pause_short, self.config.pause_long}:
+                out_tokens.append(token)
+                continue
+            out_tokens.append(self._replace_token(token))
+        return " ".join(out_tokens)
 
 
 __all__ = ["Normalizer"]

--- a/src/furlan_g2p/phonology/inventory.py
+++ b/src/furlan_g2p/phonology/inventory.py
@@ -1,4 +1,8 @@
-"""Canonical phoneme inventory used by FurlanG2P."""
+"""Canonical phoneme inventory used by FurlanG2P.
+
+The list is based on descriptions by ARLeF and Miotti (2002) as catalogued in
+``docs/references.md``.
+"""
 
 from __future__ import annotations
 
@@ -34,8 +38,12 @@ PHONEME_INVENTORY: list[str] = [
     "n",
     "ɲ",
     "j",
-    # affricate
+    "ʎ",
+    # affricates
     "tʃ",
+    "dʒ",
+    "dz",
+    "ts",
     # pauses
     "_",
     "__",

--- a/src/furlan_g2p/phonology/ipa.py
+++ b/src/furlan_g2p/phonology/ipa.py
@@ -3,10 +3,21 @@
 from __future__ import annotations
 
 import re
+import unicodedata
 
+# Common digraphs and symbol variants that should collapse to a canonical
+# representation.  The list is based on attested IPA strings in Friulian
+# sources [1] and typical transcriber variation.
 _REPLACEMENTS: dict[str, str] = {
-    "t͡ʃ": "tʃ",
-    "ɡ": "g",
+    "t͡ʃ": "tʃ",  # remove tie bar in affricates
+    "d͡ʒ": "dʒ",
+    "t͡s": "ts",
+    "d͡z": "dz",
+    "ʧ": "tʃ",
+    "ʤ": "dʒ",
+    "ɡ": "g",  # map script g to typographic g
+    "ɹ": "r",  # use alveolar trill/tap symbol
+    "ɾ": "r",
     "ɳ": "ɲ",
 }
 
@@ -14,12 +25,16 @@ _REPLACEMENTS: dict[str, str] = {
 def canonicalize_ipa(ipa: str) -> str:
     """Return a canonical representation of ``ipa``.
 
-    This helper normalizes a few symbol variants used in the seed data and
-    rule-based converters:
+    The function strips extraneous delimiters, normalises Unicode codepoints and
+    collapses known symbol variants so that downstream components operate on a
+    stable IPA alphabet.
 
     - removes leading/trailing slashes and syllable separators ``.``;
-    - maps ``t͡ʃ`` → ``tʃ`` and ``ɡ`` → ``g``;
-    - normalizes ``ɳ`` to ``ɲ``;
+    - normalises tie bars and variant affricate symbols to digraphs (``t͡ʃ`` →
+      ``tʃ`` etc.);
+    - maps tap/approximant ``ɾ``/``ɹ`` to ``r`` and ``ɡ`` to ``g``;
+    - normalises ``ɳ`` to ``ɲ``;
+    - converts alternative stress marks (``'``/``ˊ``) to ``ˈ``;
     - collapses multiple spaces.
 
     Parameters
@@ -31,14 +46,20 @@ def canonicalize_ipa(ipa: str) -> str:
     -------
     str
         Canonical IPA string.
+
+    References
+    ----------
+    [1] ARLeF (2017). *La grafie uficiâl de lenghe furlane*.
     """
 
-    s = ipa.strip()
+    s = unicodedata.normalize("NFC", ipa.strip())
     if s.startswith("/") and s.endswith("/"):
         s = s[1:-1]
     s = s.replace(".", "")
+    s = s.replace("͡", "")  # stray tie bars
     for src, tgt in _REPLACEMENTS.items():
         s = s.replace(src, tgt)
+    s = re.sub(r"[ˊ']", "ˈ", s)  # unify primary stress marks
     s = re.sub(r"\s+", " ", s).strip()
     return s
 

--- a/src/furlan_g2p/phonology/stress.py
+++ b/src/furlan_g2p/phonology/stress.py
@@ -1,4 +1,4 @@
-"""Stress assignment helpers (skeleton)."""
+"""Stress assignment helpers."""
 
 from __future__ import annotations
 
@@ -6,31 +6,55 @@ from ..core.interfaces import IStressAssigner
 
 
 class StressAssigner(IStressAssigner):
-    """Very small stress assignment helper.
+    """Heuristic stress assigner for Friulian.
 
-    Friulian words are generally stressed on the penultimate syllable and a
-    grave accent is used to mark exceptions, while a circumflex indicates a
-    long stressed vowel [1] [2].  This helper applies primary stress to the
-    penultimate syllable as a simple heuristic.
+    The default rule stresses the penultimate syllable, but the implementation
+    also accounts for marked accents and long vowels which often indicate a
+    stressed final syllable [1] [2].  If a syllable already carries a stress
+    marker, it is preserved.
 
     Examples
     --------
     >>> StressAssigner().assign_stress([['o'], ['r', 'e'], ['l', 'e']])
     [['o'], ['ˈr', 'e'], ['l', 'e']]
+    >>> StressAssigner().assign_stress([['p', 'a'], ['t', 'iː']])
+    [['p', 'a'], ['ˈt', 'iː']]
     """
 
     # References
     # ----------
     # [1] ARLeF. (2017). *La grafie uficiâl de lenghe furlane*, §10.
-    # [2] Omniglot. Friulian language.
+    # [2] Miotti, R. (2002). *Friulian*. Journal of the International
+    #     Phonetic Association, 32(2), 249–254.
 
     def assign_stress(self, syllables: list[list[str]]) -> list[list[str]]:
-        """Apply stress markers to ``syllables`` using a penultimate rule."""
+        """Return ``syllables`` with primary stress markers applied.
+
+        If a syllable already starts with ``ˈ`` the input is returned
+        unchanged.  Otherwise the last syllable containing a long vowel
+        (``ː``) is stressed.  If no long vowel is found, the penultimate
+        syllable receives stress, or the final one in monosyllables.
+        """
 
         if not syllables:
             return []
         out = [list(s) for s in syllables]
-        idx = max(0, len(out) - 2)
+
+        # Respect pre-marked stress
+        if any(syl and syl[0].startswith("ˈ") for syl in out):
+            return out
+
+        # Long vowel heuristic
+        long_idx = None
+        for idx, syl in enumerate(out):
+            if any("ː" in ph for ph in syl):
+                long_idx = idx
+
+        if long_idx is not None:
+            out[long_idx][0] = "ˈ" + out[long_idx][0]
+            return out
+
+        idx = 0 if len(out) == 1 else len(out) - 2
         out[idx][0] = "ˈ" + out[idx][0]
         return out
 

--- a/src/furlan_g2p/phonology/syllabifier.py
+++ b/src/furlan_g2p/phonology/syllabifier.py
@@ -1,4 +1,4 @@
-"""Syllabification helpers."""
+"""Syllabification helpers with basic Friulian phonotactics."""
 
 from __future__ import annotations
 
@@ -6,28 +6,84 @@ from collections.abc import Iterable
 
 from ..core.interfaces import ISyllabifier
 
+_VOWELS = set("aeiouɛɔ")
+
 
 def _is_vowel(ph: str) -> bool:
-    return ph[0] in "aeiou"
+    """Return ``True`` if ``ph`` is a vowel symbol."""
+
+    return ph[0] in _VOWELS
+
+
+def _combine_length(phonemes: list[str]) -> list[str]:
+    """Merge length markers with the preceding vowel.
+
+    Parameters
+    ----------
+    phonemes:
+        Raw phoneme list possibly containing standalone ``ː`` markers.
+
+    Returns
+    -------
+    list[str]
+        List where long vowels appear as single elements (e.g. ``aː``).
+    """
+
+    combined: list[str] = []
+    i = 0
+    while i < len(phonemes):
+        ph = phonemes[i]
+        if _is_vowel(ph) and i + 1 < len(phonemes) and phonemes[i + 1] == "ː":
+            combined.append(ph + "ː")
+            i += 2
+        else:
+            combined.append(ph)
+            i += 1
+    return combined
+
+
+# Allow complex onsets such as ``pr``/``st``/``spl``.
+_ALLOWED_ONSETS: set[tuple[str, ...]] = {
+    ("p", "r"),
+    ("p", "l"),
+    ("b", "r"),
+    ("b", "l"),
+    ("t", "r"),
+    ("d", "r"),
+    ("k", "r"),
+    ("k", "l"),
+    ("g", "r"),
+    ("g", "l"),
+    ("f", "r"),
+    ("f", "l"),
+    ("s", "p", "r"),
+    ("s", "p", "l"),
+    ("s", "t", "r"),
+    ("s", "k", "r"),
+    ("s", "k", "l"),
+}
 
 
 class Syllabifier(ISyllabifier):
-    """Basic syllabifier using onset maximization.
+    """Syllabifier using onset maximisation and basic clusters.
 
-    Consonant clusters between vowels are split so that the last consonant
-    begins the following syllable; clusters ending in ``r``, ``l`` or ``j`` are
-    allowed as complex onsets.
+    Consonant groups between vowels are split so that the maximal permissible
+    onset attaches to the following syllable.  Complex clusters such as ``pr``,
+    ``str`` or ``scl`` are accepted when listed in ``_ALLOWED_ONSETS``.  Standalone
+    length markers are merged with the preceding vowel before processing.
 
     Examples
     --------
     >>> Syllabifier().syllabify(['o', 'r', 'e', 'l', 'e'])
     [['o'], ['r', 'e'], ['l', 'e']]
+    >>> Syllabifier().syllabify(['s', 't', 'r', 'i', 'ɛ'])
+    [['s', 't', 'r', 'i'], ['ɛ']]
     """
 
     def syllabify(self, phonemes: Iterable[str]) -> list[list[str]]:
-        """Split a phoneme sequence into syllables."""
+        """Split ``phonemes`` into a list of syllables."""
 
-        phs = list(phonemes)
+        phs = _combine_length(list(phonemes))
         syllables: list[list[str]] = []
         onset: list[str] = []
         i = 0
@@ -41,12 +97,14 @@ class Syllabifier(ISyllabifier):
                     cluster.append(phs[i])
                     i += 1
                 if i < len(phs):
-                    if len(cluster) >= 2 and cluster[-1] in {"r", "l", "j"}:
-                        coda = cluster[:-2]
-                        next_onset = cluster[-2:]
-                    else:
-                        coda = cluster[:-1]
-                        next_onset = cluster[-1:]
+                    split = len(cluster)
+                    for size in range(min(3, len(cluster)), 0, -1):
+                        cand = tuple(cluster[-size:])
+                        if cand in _ALLOWED_ONSETS or size == 1:
+                            split = len(cluster) - size
+                            break
+                    coda = cluster[:split]
+                    next_onset = cluster[split:]
                     syllables.append(onset + [nucleus] + coda)
                     onset = next_onset
                 else:

--- a/src/furlan_g2p/tokenization/tokenizer.py
+++ b/src/furlan_g2p/tokenization/tokenizer.py
@@ -1,4 +1,4 @@
-"""Sentence and word tokenization utilities (skeleton)."""
+"""Sentence and word tokenization utilities."""
 
 from __future__ import annotations
 
@@ -7,22 +7,26 @@ import re
 from ..config.schemas import TokenizerConfig
 from ..core.interfaces import ITokenizer
 
+_WORD_RE = re.compile(r"[a-zà-öø-ÿç0-9'’]+|_{1,2}", re.IGNORECASE)
+
 
 class Tokenizer(ITokenizer):
     """Sentence and word tokenizer.
 
-    The implementation is intentionally simple and aims only to provide the
-    basic functionality required by the tests.  Sentences are split on ``.``,
-    ``!`` and ``?`` followed by whitespace; words are extracted as contiguous
-    alphabetic sequences (including accented letters and apostrophes).
+    Sentences are split on ``.``, ``!`` and ``?`` while honouring abbreviations
+    that should *not* trigger a boundary (e.g. ``sig.``).  Words are extracted
+    as contiguous alphanumeric sequences (including accented letters and
+    apostrophes); pause markers ``_`` and ``__`` are preserved as standalone
+    tokens.
 
     Examples
     --------
-    >>> t = Tokenizer()
-    >>> t.split_sentences("A. B!")
-    ['A.', 'B!']
-    >>> t.split_words("Bêle cjase!")
-    ['bêle', 'cjase']
+    >>> cfg = TokenizerConfig(abbrev_no_split={"sig"})
+    >>> t = Tokenizer(cfg)
+    >>> t.split_sentences("Al è rivât il Sig. Bepo. O ven?")
+    ['Al è rivât il Sig. Bepo.', 'O ven?']
+    >>> t.split_words("L’aghe __ e je freda _")
+    ["l'aghe", '__', 'e', 'je', 'freda', '_']
     """
 
     def __init__(self, config: TokenizerConfig | None = None) -> None:
@@ -42,7 +46,12 @@ class Tokenizer(ITokenizer):
             Sentence fragments including their terminal punctuation.
         """
 
-        sentences = [s for s in re.split(r"(?<=[.!?])\s+", text.strip()) if s]
+        sentinel = "\uffff"  # unlikely char used as temporary placeholder
+        work = text.strip()
+        for abbr in self.config.abbrev_no_split:
+            pattern = re.compile(rf"\b{re.escape(abbr)}\.", re.IGNORECASE)
+            work = pattern.sub(lambda m: m.group(0).replace(".", sentinel), work)
+        sentences = [s.replace(sentinel, ".") for s in re.split(r"(?<=[.!?])\s+", work) if s]
         return sentences
 
     def split_words(self, sentence: str) -> list[str]:
@@ -59,7 +68,8 @@ class Tokenizer(ITokenizer):
             Lowercase word tokens without punctuation.
         """
 
-        return re.findall(r"[a-zâêîôûàèìòùç'’]+", sentence.lower())
+        s = sentence.replace("’", "'").lower()
+        return _WORD_RE.findall(s)
 
 
 __all__ = ["Tokenizer"]

--- a/tests/data/pipeline_golden.tsv
+++ b/tests/data/pipeline_golden.tsv
@@ -1,0 +1,3 @@
+Cjase|cjase|ˈc a z e
+Gjat|gjat|ˈɟ a t
+Zûc|zûc|ˈdz uː tʃ

--- a/tests/test_cli_errors.py
+++ b/tests/test_cli_errors.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from furlan_g2p.cli.app import cli
+
+
+def test_normalize_requires_input() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["normalize"])
+    assert result.exit_code != 0
+    assert "No input provided" in result.output
+
+
+def test_normalize_conflicting_sources(tmp_path: Path) -> None:
+    src = tmp_path / "in.txt"
+    src.write_text("cjase", encoding="utf-8")
+    runner = CliRunner()
+    result = runner.invoke(cli, ["normalize", "--in", str(src), "Cjase"])
+    assert result.exit_code != 0
+    assert "Provide either TEXT or --in" in result.output
+
+
+def test_phonemize_csv_missing_file(tmp_path: Path) -> None:
+    out = tmp_path / "o.csv"
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["phonemize-csv", "--in", str(tmp_path / "missing.csv"), "--out", str(out)],
+    )
+    assert result.exit_code != 0
+    assert "Could not open file" in result.output

--- a/tests/test_cli_pipeline_commands.py
+++ b/tests/test_cli_pipeline_commands.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from furlan_g2p.cli.app import cli
+
+
+def test_cli_normalize() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["normalize", "CJASE", "1964", "kg"])
+    assert result.exit_code == 0
+    assert result.output.strip() == "cjase mil nûfcent e sessantecuatri chilogram"
+
+
+def test_cli_g2p() -> None:
+    runner = CliRunner()
+    result = runner.invoke(cli, ["g2p", "Cjase"])
+    assert result.exit_code == 0
+    assert result.output.strip() == "ˈc a z e"
+
+
+def test_cli_phonemize_csv(tmp_path: Path) -> None:
+    inp = tmp_path / "meta.csv"
+    inp.write_text("utt0|Cjase\n", encoding="utf-8")
+    out = tmp_path / "out.csv"
+    runner = CliRunner()
+    result = runner.invoke(cli, ["phonemize-csv", "--in", str(inp), "--out", str(out)])
+    assert result.exit_code == 0
+    assert out.read_text(encoding="utf-8").strip() == "utt0|cjase|ˈc a z e"

--- a/tests/test_lexicon_gold.py
+++ b/tests/test_lexicon_gold.py
@@ -44,6 +44,8 @@ GOLD = {
     "pît": "piːt",
     "mûr": "muːr",
     "côr": "kɔːr",
+    "gjat": "ɟat",
+    "zûc": "dzuːk",
 }
 
 
@@ -67,6 +69,10 @@ def test_variants_present_for_selected(lex: Lexicon) -> None:
     assert entry is not None and "seit" in entry.variants
     entry = lex.get_entry("pît")
     assert entry is not None and "peit" in entry.variants
+    entry = lex.get_entry("gjat")
+    assert entry is not None and "dʒat" in entry.variants
+    entry = lex.get_entry("zûc")
+    assert entry is not None and "tsuːk" in entry.variants
 
 
 def test_unknown_returns_none(lex: Lexicon) -> None:

--- a/tests/test_normalizer.py
+++ b/tests/test_normalizer.py
@@ -4,8 +4,8 @@ import unicodedata
 from collections.abc import Callable
 from typing import Any, TypeVar, cast
 
-from hypothesis import given as _given
-from hypothesis import strategies as st
+from hypothesis import given as _given  # type: ignore[import-not-found,unused-ignore]
+from hypothesis import strategies as st  # type: ignore[import-not-found,unused-ignore]
 
 from furlan_g2p.normalization.experimental_normalizer import ExperimentalNormalizer
 

--- a/tests/test_normalizer_expansion.py
+++ b/tests/test_normalizer_expansion.py
@@ -22,6 +22,12 @@ def test_basic_expansions() -> None:
     assert norm.normalize("2 kg, Sig. SOS") == "doi chilogram _ siôr __ esse o esse"
 
 
+def test_number_spellout() -> None:
+    norm = Normalizer()
+    assert norm.normalize("2004") == "doi mil e cuatri"
+    assert norm.normalize("1964") == "mil nûfcent e sessantecuatri"
+
+
 def test_load_config_json(tmp_path: Path) -> None:
     data = {
         "numbers_map": {"3": "trê"},

--- a/tests/test_normalizer_expansion.py
+++ b/tests/test_normalizer_expansion.py
@@ -1,0 +1,49 @@
+"""Tests for Normalizer expansion and config loading."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from furlan_g2p.config import NormalizerConfig, load_normalizer_config
+from furlan_g2p.normalization.normalizer import Normalizer
+
+
+def test_basic_expansions() -> None:
+    cfg = NormalizerConfig(
+        numbers_map={"2": "doi"},
+        units_map={"kg": "chilogram"},
+        abbreviations_map={"sig": "siôr"},
+        acronyms_map={"sos": "esse o esse"},
+    )
+    norm = Normalizer(cfg)
+    assert norm.normalize("2 kg, Sig. SOS") == "doi chilogram _ siôr __ esse o esse"
+
+
+def test_load_config_json(tmp_path: Path) -> None:
+    data = {
+        "numbers_map": {"3": "trê"},
+        "abbreviations_map": {"pt": "part"},
+    }
+    path = tmp_path / "norm.json"
+    path.write_text(json.dumps(data), encoding="utf-8")
+    cfg = load_normalizer_config(path)
+    norm = Normalizer(cfg)
+    assert norm.normalize("3 pt") == "trê part"
+
+
+def test_load_config_yaml(tmp_path: Path) -> None:
+    pytest.importorskip("yaml")
+    data = {
+        "numbers_map": {"4": "cuatri"},
+        "units_map": {"km": "chilometr"},
+    }
+    path = tmp_path / "norm.yml"
+    import yaml  # type: ignore[import-untyped]
+
+    path.write_text(yaml.safe_dump(data), encoding="utf-8")
+    cfg = load_normalizer_config(path)
+    norm = Normalizer(cfg)
+    assert norm.normalize("4 km") == "cuatri chilometr"

--- a/tests/test_phoneme_rules.py
+++ b/tests/test_phoneme_rules.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, TypeVar, cast
+
+from hypothesis import given as _given
+from hypothesis import strategies as st
+
+from furlan_g2p.g2p.rules import PhonemeRules
+from furlan_g2p.phonology import PHONEME_INVENTORY
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+def given(*args: Any, **kwargs: Any) -> Callable[[F], F]:
+    return cast(Callable[[F], F], _given(*args, **kwargs))
+
+
+ALPHABET = "abcçdefghijlmnoprstuvzâêîôûàèìòù"
+
+
+@given(st.text(alphabet=ALPHABET, min_size=1, max_size=10))
+def test_rules_output_inventory(s: str) -> None:
+    rules = PhonemeRules()
+    out = rules.apply(s)
+    assert all(p in PHONEME_INVENTORY for p in out)
+
+
+def test_affricates_and_dialect() -> None:
+    rules = PhonemeRules()
+    assert rules.apply("zente") == ["dz", "e", "n", "t", "e"]
+    carn = PhonemeRules(dialect="carnia")
+    assert carn.apply("zente")[0] == "ts"
+
+
+def test_soft_g_and_palatal() -> None:
+    rules = PhonemeRules()
+    assert rules.apply("gela")[:2] == ["dʒ", "e"]
+    assert rules.apply("gjat") == ["ɟ", "a", "t"]

--- a/tests/test_phoneme_rules.py
+++ b/tests/test_phoneme_rules.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any, TypeVar, cast
 
-from hypothesis import given as _given
-from hypothesis import strategies as st
+from hypothesis import given as _given  # type: ignore[import-not-found,unused-ignore]
+from hypothesis import strategies as st  # type: ignore[import-not-found,unused-ignore]
 
 from furlan_g2p.g2p.rules import PhonemeRules
 from furlan_g2p.phonology import PHONEME_INVENTORY

--- a/tests/test_phonology_refined.py
+++ b/tests/test_phonology_refined.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from furlan_g2p.phonology.ipa import canonicalize_ipa
+from furlan_g2p.phonology.stress import StressAssigner
+from furlan_g2p.phonology.syllabifier import Syllabifier
+
+
+def test_canonicalize_ipa_variants() -> None:
+    s = canonicalize_ipa("/t\u0361s d\u0361\u0292 ɹ ʤ ɾ ˊa/")
+    assert s == "ts dʒ r dʒ r ˈa"
+
+
+def test_syllabifier_clusters_and_length() -> None:
+    syl = Syllabifier()
+    assert syl.syllabify(["s", "t", "r", "i", "ɛ"]) == [["s", "t", "r", "i"], ["ɛ"]]
+    assert syl.syllabify(["k", "u", "ː", "r"]) == [["k", "uː", "r"]]
+
+
+def test_stress_assigner_long_vowel_and_existing() -> None:
+    stress = StressAssigner()
+    assert stress.assign_stress([["p", "a"], ["t", "iː"]]) == [["p", "a"], ["ˈt", "iː"]]
+    pre = [["ˈr", "e"], ["l", "e"]]
+    assert stress.assign_stress(pre) == pre

--- a/tests/test_pipeline_basic.py
+++ b/tests/test_pipeline_basic.py
@@ -44,6 +44,9 @@ def test_pipeline_basic() -> None:
     norm2, phons2 = pipe.process_text("Orele")
     assert norm2 == "orele"
     assert phons2 == ["o", "ˈr", "e", "l", "e"]
+    norm3, phons3 = pipe.process_text("Patî")
+    assert norm3 == "patî"
+    assert phons3 == ["p", "a", "ˈt", "iː"]
 
 
 def test_io_service(tmp_path) -> None:  # type: ignore[no-untyped-def]

--- a/tests/test_pipeline_basic.py
+++ b/tests/test_pipeline_basic.py
@@ -20,7 +20,7 @@ def test_tokenizer_basic() -> None:
     tok = Tokenizer()
     assert tok.split_sentences("A. B!") == ["A.", "B!"]
     assert tok.split_words("Bêle cjase!") == ["bêle", "cjase"]
-    assert tok.split_words("L’orele e biele") == ["l’orele", "e", "biele"]
+    assert tok.split_words("L’orele e biele") == ["l'orele", "e", "biele"]
 
 
 def test_g2p_basic() -> None:

--- a/tests/test_pipeline_golden.py
+++ b/tests/test_pipeline_golden.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+from furlan_g2p.services.pipeline import PipelineService
+
+
+def test_pipeline_against_golden_set() -> None:
+    service = PipelineService()
+    data_path = Path(__file__).parent / "data" / "pipeline_golden.tsv"
+    with data_path.open(encoding="utf-8") as f:
+        reader = csv.reader(f, delimiter="|")
+        for text, expected_norm, expected_phons in reader:
+            norm, phons = service.process_text(text)
+            assert norm == expected_norm
+            assert " ".join(phons) == expected_phons

--- a/tests/test_rule_engine_properties.py
+++ b/tests/test_rule_engine_properties.py
@@ -3,8 +3,8 @@
 from collections.abc import Callable
 from typing import Any, TypeVar, cast
 
-from hypothesis import given as _given
-from hypothesis import strategies as st
+from hypothesis import given as _given  # type: ignore[import-not-found,unused-ignore]
+from hypothesis import strategies as st  # type: ignore[import-not-found,unused-ignore]
 
 from furlan_g2p.g2p.rule_engine import RuleEngine
 

--- a/tests/test_script_generate_phonemes.py
+++ b/tests/test_script_generate_phonemes.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_generate_phonemes_script(tmp_path: Path) -> None:
+    inp = tmp_path / "meta.csv"
+    inp.write_text("utt0|Cjase\n", encoding="utf-8")
+    out = tmp_path / "out.csv"
+    script = Path(__file__).resolve().parents[1] / "scripts" / "generate_phonemes.py"
+    proc = subprocess.run(
+        [sys.executable, str(script), "--in", str(inp), "--out", str(out)],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0
+    assert out.read_text(encoding="utf-8").strip() == "utt0|cjase|ˈc a z e"

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -1,0 +1,18 @@
+from furlan_g2p.config.schemas import TokenizerConfig
+from furlan_g2p.tokenization.tokenizer import Tokenizer
+
+
+def test_abbreviation_blocks_sentence_split() -> None:
+    cfg = TokenizerConfig(abbrev_no_split={"sig"})
+    tok = Tokenizer(cfg)
+    text = "Al è rivât il Sig. Bepo. O ven?"
+    assert tok.split_sentences(text) == [
+        "Al è rivât il Sig. Bepo.",
+        "O ven?",
+    ]
+
+
+def test_split_words_apostrophes_and_pauses() -> None:
+    tok = Tokenizer()
+    sent = "L’aghe, cjase! _ __"
+    assert tok.split_words(sent) == ["l'aghe", "cjase", "_", "__"]


### PR DESCRIPTION
## Summary
- support loading NormalizerConfig from JSON/YAML files
- add number, abbreviation, acronym and unit expansions in Normalizer
- document and test configurable normalization; include PyYAML in dev deps

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c04dc25070833088a55fbc59e874d5