### PR TITLE
docs: add module overview and update docs guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,8 @@ Documentation:
   and usage examples.
 - When a change affects user-facing behaviour or packaging, update the
   appropriate README(s) to keep them in sync.
+- Review and update files under `docs/` (e.g., module overviews) when business
+  logic or interfaces change.
 
 Coding standards:
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,26 @@ that raise `NotImplementedError`.
 - `scripts/` – helper scripts (future automation).
 - `tests/` – minimal tests covering the implemented pieces and stubs.
 
+See [docs/project_structure.md](docs/project_structure.md) for a full module
+overview and development roadmap.
+
+## Business logic overview
+
+The project is organised into focused modules:
+
+- **Normalization** – lowercases text and collapses whitespace. *TODO:* load
+  rule sets from configuration and expand coverage for numbers and acronyms.
+- **Tokenization** – regex-based sentence and word splitter. *TODO:* handle
+  abbreviations and preserve pause markers.
+- **G2P** – small lexicon with rule-based fallback to generate IPA strings.
+  *TODO:* implement the `PhonemeRules` engine and grow the lexicon.
+- **Phonology** – IPA canonicalization, syllabifier and stress assigner.
+  *TODO:* refine syllabification and stress rules.
+- **Services** – pipeline and file I/O helpers. *TODO:* expose dependency
+  injection and batch utilities.
+- **CLI** – user-facing commands; only `ipa` is functional. *TODO:* implement
+  `normalize`, `g2p` and `phonemize-csv` subcommands.
+
 ## Quick local run (how to launch the CLI and test phrases)
 
 1. Create and activate a virtual environment:

--- a/docs/project_structure.md
+++ b/docs/project_structure.md
@@ -1,0 +1,90 @@
+# Project structure and status
+
+This document outlines the main business logic modules in FurlanG2P, their responsibilities, current development state and planned work.
+
+## Normalization (`src/furlan_g2p/normalization/`)
+**Purpose.** Convert raw text into a normalized form.
+
+**Status.** `Normalizer` collapses whitespace and lowercases tokens; an `ExperimentalNormalizer` offers rudimentary tokenization for testing.
+
+**TODO.**
+- Load rule sets from configuration.
+- Expand normalization rules for numbers, acronyms and punctuation.
+- Unify experimental normalizer with the public API.
+
+## Tokenization (`src/furlan_g2p/tokenization/`)
+**Purpose.** Split normalized text into sentences and word tokens.
+
+**Status.** Regex-based splitter without abbreviation handling or pause management.
+
+**TODO.**
+- Handle abbreviations and honorifics that should not split sentences.
+- Preserve pause markers and non speech tokens.
+- Provide word-level configuration hooks.
+
+## G2P (`src/furlan_g2p/g2p/`)
+**Purpose.** Map tokens to phoneme sequences using a lexicon and rule engine.
+
+**Status.** `Lexicon` loads a small TSV; `RuleEngine` covers a handful of digraphs and vowel contrasts; `PhonemeRules.apply` is unimplemented.
+
+**TODO.**
+- Grow the packaged lexicon and expose source metadata.
+- Implement the `PhonemeRules` letter‑to‑sound engine.
+- Support dialectal variants and a managed phoneme inventory.
+
+## Phonology (`src/furlan_g2p/phonology/`)
+**Purpose.** Post-process phoneme strings: canonicalization, syllabification and stress.
+
+**Status.** Heuristic `Syllabifier` and penultimate-stress `StressAssigner` are in place; other phonological processes are absent.
+
+**TODO.**
+- Refine syllabification to cover complex clusters and hiatus.
+- Implement lexical and post‑lexical stress rules.
+- Expand helpers for allophony and prosody.
+
+## Services (`src/furlan_g2p/services/`)
+**Purpose.** High-level orchestration and I/O helpers.
+
+**Status.** `PipelineService` chains the normalizer, tokenizer, phonemizer and phonology; `IOService` handles UTF‑8 text files.
+
+**TODO.**
+- Allow dependency injection and configuration of pipeline components.
+- Wire services into CLI subcommands and batch processors.
+- Add streaming and asynchronous interfaces.
+
+## CLI (`src/furlan_g2p/cli/`)
+**Purpose.** User-facing command-line tools.
+
+**Status.** Only the `ipa` command works; `normalize`, `g2p` and `phonemize-csv` raise `NotImplementedError`.
+
+**TODO.**
+- Implement remaining subcommands using `PipelineService`.
+- Provide option groups for dialect, output format and config files.
+- Add CSV batch phonemization utility.
+
+## Config (`src/furlan_g2p/config/`)
+**Purpose.** Typed configuration schemas for pipeline components.
+
+**Status.** Dataclasses exist but are not yet loaded from user-provided files.
+
+**TODO.**
+- Parse configuration from TOML/YAML files.
+- Validate and merge user overrides.
+
+## Core (`src/furlan_g2p/core/`)
+**Purpose.** Shared interfaces, type aliases and exceptions.
+
+**Status.** Interfaces define stable public contracts.
+
+**TODO.**
+- Extend error hierarchy with richer context.
+- Document interface guarantees for contributors.
+
+## Data (`src/furlan_g2p/data/`)
+**Purpose.** Packaged resources such as the seed lexicon.
+
+**Status.** Contains a minimal TSV lexicon for testing.
+
+**TODO.**
+- Expand lexical coverage and include metadata about sources and variants.
+


### PR DESCRIPTION
## Summary
- expand README with business-logic overview and TODOs
- add `docs/project_structure.md` outlining modules and development status
- clarify in `AGENTS.md` that docs in `docs/` must be kept updated

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7d49c230c833081b5952757c03e90