### PR TITLE
docs: add architecture and business logic docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,9 @@ Documentation:
   and usage examples.
 - When a change affects user-facing behaviour or packaging, update the
   appropriate README(s) to keep them in sync.
+- Documentation under `docs/` (architecture, business logic, roadmap, etc.)
+  must be reviewed and updated when code changes alter module behaviour or
+  project structure.
 
 Coding standards:
 

--- a/README.md
+++ b/README.md
@@ -20,9 +20,11 @@ G2P conversion and batch phonemization of CSV files.
 - `src/furlan_g2p/phonology/` – canonical IPA helpers, syllabifier and stress
   assigner.
 - `examples/` – sample inputs and outputs.
-- `docs/` – supplementary documentation and bibliography.
+- `docs/` – supplementary documentation: rationale, usage, references, [architecture](docs/architecture.md), [business logic](docs/business_logic.md) and [roadmap](docs/todo.md).
 - `scripts/` – helper scripts (e.g. `generate_phonemes.py` for CSV batch runs).
 - `tests/` – minimal tests covering the implemented pieces and stubs.
+
+For a deeper overview of how components fit together and the algorithms they employ, see [docs/architecture.md](docs/architecture.md) and [docs/business_logic.md](docs/business_logic.md). Planned work is tracked in [docs/todo.md](docs/todo.md).
 
 ## Quick local run (how to launch the CLI and test phrases)
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ G2P conversion and batch phonemization of CSV files.
 - `scripts/` – helper scripts (e.g. `generate_phonemes.py` for CSV batch runs).
 - `tests/` – minimal tests covering the implemented pieces and stubs.
 
-For a deeper overview of how components fit together and the algorithms they employ, see [docs/architecture.md](docs/architecture.md) and [docs/business_logic.md](docs/business_logic.md). Planned work is tracked in [docs/todo.md](docs/todo.md).
+For detailed documentation on component interactions and algorithmic design, consult [docs/architecture.md](docs/architecture.md) and [docs/business_logic.md](docs/business_logic.md). Ongoing and planned work is documented in [docs/todo.md](docs/todo.md).
 
 ## Quick local run (how to launch the CLI and test phrases)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,26 @@
+# Project Architecture
+
+FurlanG2P is organised as a set of small, typed modules that compose a text‑to‑phoneme pipeline.
+
+## Module map
+
+| Package | Responsibility | Design notes | Maturity |
+| --- | --- | --- | --- |
+| `core` | exceptions, abstract interfaces, shared type aliases | interface‑driven design with custom error hierarchy | stable |
+| `config` | dataclass configs and JSON/YAML loaders | optional `pyyaml` dependency, type‑checked dataclasses | prototype |
+| `normalization` | deterministic text normalisation and number spelling | rules layer extensible via `NormalizerConfig` | prototype |
+| `tokenization` | sentence and word tokeniser | regex engine with abbreviation sentinel replacement | prototype |
+| `g2p` | seed lexicon, letter‑to‑sound rules and phonemiser | LRU‑cached lookups, dialect flag, inventory validation | experimental |
+| `phonology` | IPA canonicaliser, syllabifier and stress assigner | onset‑maximisation, heuristic stress rules | experimental |
+| `services` | orchestrating pipeline and simple file I/O | service layer encapsulating pipeline steps | minimal |
+| `cli` | `click` entry points and subcommands | thin wrapper over services | minimal |
+| `data` | packaged seed lexicon TSV | loaded via `importlib.resources` | seed |
+| `docs` | usage, rationale, references and internal docs | kept in sync with source modules | evolving |
+| `tests` | regression and property tests | guard implemented behaviour | provisional |
+
+## Architectural patterns
+
+- **Interface driven** – `core.interfaces` defines `INormalizer`, `ITokenizer`, `IG2PPhonemizer`, `ISyllabifier` and `IStressAssigner` so implementations can evolve behind stable APIs.
+- **Service layer** – `services.PipelineService` composes normalisation → tokenisation → G2P → phonology into a reusable pipeline.
+- **Resource packaging** – `g2p.Lexicon` ships a TSV lexicon inside the wheel and accesses it with `importlib.resources`.
+- **Configuration via dataclasses** – normalisation and tokenisation behaviour is configured through dataclasses loaded from JSON or YAML files.

--- a/docs/business_logic.md
+++ b/docs/business_logic.md
@@ -1,0 +1,31 @@
+# Business Logic
+
+This document summarises the algorithms and linguistic rules implemented in FurlanG2P.
+
+## Normalisation
+- NFC‐normalises input and lowercases.
+- Converts curly apostrophes to straight ones.
+- Maps `, ; :` to short pause `_` and `. ? !` to long pause `__`.
+- Expands units, abbreviations, acronyms and ordinals via `NormalizerConfig` mappings.
+- Numbers up to 999 999 999 999 are spelled out in Friulian (`number_to_words_fr`).
+
+## Tokenisation
+- `split_sentences` replaces non‑terminal abbreviations with a sentinel character then splits on sentence‑final punctuation.
+- `split_words` normalises apostrophes and extracts tokens with a regex that preserves underscore pause markers.
+
+## Grapheme‑to‑Phoneme
+- `Lexicon` provides IPA transcriptions from `seed_lexicon.tsv`; lookups are NFC‑lowercased and LRU‑cached.
+- `PhonemeRules` performs deterministic orthography→IPA mapping:
+  - handles digraphs (`ch`, `gh`, `cj`, `gj`, `gn`, `gl`, `ss`).
+  - converts circumflex vowels to long monophthongs (`â`→`aː`, etc.).
+  - applies contextual voicing (`s`→`z` between vowels, `z` dialectal choices).
+  - segments the resulting IPA and validates symbols against `PHONEME_INVENTORY`.
+- `G2PPhonemizer` consults the lexicon first and falls back to the rule engine; stress markers are stripped before segmentation.
+
+## Phonology
+- `canonicalize_ipa` removes tie bars and normalises variant symbols (`t͡ʃ`→`tʃ`, `ɹ`→`r`, etc.).
+- `Syllabifier` merges standalone length marks with the preceding vowel and applies onset maximisation with a whitelist of clusters.
+- `StressAssigner` preserves pre‑marked stress, otherwise stresses the last long vowel or the penultimate syllable.
+
+## Pipeline
+`PipelineService` chains normalisation → sentence split → word split → G2P → syllabification → stress assignment and returns the normalised text alongside the final phoneme sequence.

--- a/docs/business_logic.md
+++ b/docs/business_logic.md
@@ -1,31 +1,41 @@
 # Business Logic
 
-This document summarises the algorithms and linguistic rules implemented in FurlanG2P.
+This document details the algorithms and linguistic rules implemented in FurlanG2P. A bibliography for the sources cited here is maintained in [references.md](references.md).
 
 ## Normalisation
-- NFC‐normalises input and lowercases.
-- Converts curly apostrophes to straight ones.
-- Maps `, ; :` to short pause `_` and `. ? !` to long pause `__`.
-- Expands units, abbreviations, acronyms and ordinals via `NormalizerConfig` mappings.
-- Numbers up to 999 999 999 999 are spelled out in Friulian (`number_to_words_fr`).
+
+The normalisation step enforces a canonical textual form that mirrors the spelling rules in the official Friulian orthography [ARLeF 2017](references.md). Key operations include:
+
+- Unicode NFC normalisation and lower‑casing.
+- Replacing curly apostrophes with straight ones so contractions match lexicon entries.
+- Mapping `, ; :` to the short pause marker `_` and `. ? !` to the long pause marker `__` for downstream prosody hints.
+- Expanding measurement units, abbreviations, acronyms and ordinals according to a `NormalizerConfig` that can be loaded from JSON or YAML.
+- Rendering numbers up to 999 999 999 999 as Friulian words using the built‑in `number_to_words_fr` utility, whose forms are based on Wiktionary’s cardinal list [Wiktionary](references.md#numbers-and-abbreviations).
 
 ## Tokenisation
-- `split_sentences` replaces non‑terminal abbreviations with a sentinel character then splits on sentence‑final punctuation.
-- `split_words` normalises apostrophes and extracts tokens with a regex that preserves underscore pause markers.
+
+Tokenisation occurs in two passes. `split_sentences` shields non‑terminal abbreviations with a sentinel character before splitting on sentence‑final punctuation, ensuring that strings such as `dr.` are not treated as sentence boundaries. `split_words` then normalises apostrophes and extracts tokens with a regular expression that preserves underscore pause markers so subsequent modules can retain pause information.
 
 ## Grapheme‑to‑Phoneme
-- `Lexicon` provides IPA transcriptions from `seed_lexicon.tsv`; lookups are NFC‑lowercased and LRU‑cached.
-- `PhonemeRules` performs deterministic orthography→IPA mapping:
-  - handles digraphs (`ch`, `gh`, `cj`, `gj`, `gn`, `gl`, `ss`).
-  - converts circumflex vowels to long monophthongs (`â`→`aː`, etc.).
-  - applies contextual voicing (`s`→`z` between vowels, `z` dialectal choices).
-  - segments the resulting IPA and validates symbols against `PHONEME_INVENTORY`.
-- `G2PPhonemizer` consults the lexicon first and falls back to the rule engine; stress markers are stripped before segmentation.
+
+The G2P component combines lexicon lookups with rule‑based conversion:
+
+- `Lexicon` supplies IPA transcriptions from `seed_lexicon.tsv`; lookups are NFC‑normalised, lower‑cased and cached with an LRU strategy.
+- `PhonemeRules` implements deterministic orthography→IPA mapping derived from the ARLeF guide to Friulian spelling [ARLeF 2017](references.md):
+  - digraph handling for sequences such as `ch`, `gh`, `cj`, `gj`, `gn`, `gl` and `ss`.
+  - conversion of circumflex vowels to long monophthongs (`â`→`aː`, `î`→`iː`, etc.).
+  - contextual voicing of `s` between vowels and dialect‑aware treatment of `z`, following observations by Baroni & Vanelli (2000) [Baroni & Vanelli 2000](references.md).
+  - segmentation of the resulting IPA string and validation of each symbol against `PHONEME_INVENTORY` compiled from ARLeF and Miotti (2002) [Miotti 2002](references.md).
+- `G2PPhonemizer` queries the lexicon first and falls back to the rule engine; any stress marks present in the input are removed before segmentation so that stress assignment can be applied uniformly later.
 
 ## Phonology
-- `canonicalize_ipa` removes tie bars and normalises variant symbols (`t͡ʃ`→`tʃ`, `ɹ`→`r`, etc.).
-- `Syllabifier` merges standalone length marks with the preceding vowel and applies onset maximisation with a whitelist of clusters.
-- `StressAssigner` preserves pre‑marked stress, otherwise stresses the last long vowel or the penultimate syllable.
+
+Phonological post‑processing standardises and analyses the IPA output:
+
+- `canonicalize_ipa` removes tie bars and normalises variant symbols (`t͡ʃ`→`tʃ`, `ɹ`→`r`, etc.) to ease downstream processing.
+- `Syllabifier` merges standalone length marks with the preceding vowel and applies onset maximisation using a whitelist of allowable clusters described by Miotti (2002) [Miotti 2002](references.md) and Roseano & Finco (2021) [Roseano & Finco 2021](references.md).
+- `StressAssigner` honours pre‑marked stress; otherwise it stresses the last long vowel or, if none, the penultimate syllable, reflecting the generalisations noted by Baroni & Vanelli (2000) [Baroni & Vanelli 2000](references.md).
 
 ## Pipeline
-`PipelineService` chains normalisation → sentence split → word split → G2P → syllabification → stress assignment and returns the normalised text alongside the final phoneme sequence.
+
+`PipelineService` orchestrates the modules in the sequence normalisation → sentence split → word split → G2P → syllabification → stress assignment and returns the normalised text together with the final phoneme sequence, enabling batch or interactive processing through the CLI.

--- a/docs/todo.md
+++ b/docs/todo.md
@@ -1,0 +1,31 @@
+# Roadmap
+
+## High Priority
+- **Expand grapheme‑to‑phoneme coverage**
+  - Implementation: grow `seed_lexicon.tsv`, extend `PhonemeRules` for additional digraphs and dialectal variation, validate against `PHONEME_INVENTORY`.
+  - Testing: add golden pronunciations under `tests/data/` and property tests for new rules.
+- **Refine phonology components**
+  - Implementation: improve `Syllabifier` cluster handling and enhance `StressAssigner` with secondary stress and vowel reduction rules.
+  - Testing: extend `tests/test_phonology_refined.py` and add edge‑case fixtures.
+- **Comprehensive test suite**
+  - Implementation: broaden CLI and pipeline tests, create fixtures for configuration loading.
+  - Testing: run `ruff`, `black`, `mypy` and `pytest` locally and in CI.
+
+## Medium Priority
+- **Augment normalisation rules**
+  - Implementation: support locale‑specific number formats and richer abbreviation and unit tables loaded from config files.
+  - Testing: configuration round‑trip tests and examples covering numeric edge cases.
+- **Configurable tokenisation**
+  - Implementation: allow external patterns for sentence boundaries and pause markers; support abbreviations with trailing digits.
+  - Testing: add parametrised tests in `tests/test_tokenizer.py`.
+- **Phoneme inventory management**
+  - Implementation: expose inventory differences between dialects and surface warnings for unknown symbols.
+  - Testing: verify inventory errors with dedicated unit tests.
+
+## Nice to Have
+- **Advanced CLI features**
+  - Implementation: progress reporting for CSV phonemisation, streaming mode and plugin registration for custom pipeline stages.
+  - Testing: snapshot tests for CLI output and large‑file smoke tests.
+- **Documentation tooling**
+  - Implementation: auto‑generate API docs and publish the `docs/` tree to a static site.
+  - Testing: build documentation in CI to catch broken links or formatting issues.


### PR DESCRIPTION
## Summary
- document project structure and architectural patterns
- outline normalization, tokenization, G2P and phonology algorithms
- track high-priority tasks and roadmap in docs/todo.md
- update README and AGENTS guidelines accordingly

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `pytest`