### PR TITLE
docs: add changelog and link from READMEs

### DIFF
--- a/README-pypi.md
+++ b/README-pypi.md
@@ -107,6 +107,7 @@ fine-grained control.
 
 - Source code and issue tracker: https://github.com/daurmax/FurlanG2P
 - Bibliography and references: https://github.com/daurmax/FurlanG2P/blob/main/docs/references.md
+- Changelog: https://github.com/daurmax/FurlanG2P/blob/main/docs/CHANGELOG.md
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -212,6 +212,11 @@ To publish a release:
    ``main``, builds wheels/sdist and uploads them to PyPI via the
    ``PYPI_API_TOKEN`` secret.
 
+## Changelog
+
+Release notes for each published version are tracked in
+[`docs/CHANGELOG.md`](docs/CHANGELOG.md).
+
 ## References
 
 FurlanG2P follows published descriptions of Friulian orthography and

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+## [0.0.2]
+
+### Added
+- Experimental `furlang2p ipa` CLI subcommand that combines the seed lexicon with a
+  rule-based fallback, supports pause tokens and optional IPA slashes.
+- Packaged Friulian seed lexicon, canonical IPA normaliser and lightweight rule
+  engine derived from the sources in `docs/references.md`.
+- Minimal-yet-functional implementations for normalization, tokenization,
+  grapheme-to-phoneme conversion, syllabification, stress assignment, pipeline
+  processing and basic file I/O.
+- Continuous-integration workflow covering linting, formatting, typing and test
+  runs across Python 3.10–3.12, plus an automated release workflow that bumps
+  versions, builds wheels/sdists and publishes to PyPI.
+- Documentation updates describing rule rationale and bibliographic references,
+  alongside a property-based test suite for the new components.
+
+### Changed
+- Project metadata now reads the package version from `src/furlan_g2p/__about__.py`
+  via Hatch's dynamic versioning and lists the maintainer contact details.
+
+## [0.0.1]
+
+### Added
+- Initial library skeleton with interface stubs, CLI scaffold and packaging
+  configuration to explore a Friulian G2P pipeline.


### PR DESCRIPTION
## Summary
- add docs/CHANGELOG.md with release notes for 0.0.1 and 0.0.2
- link the changelog from the main README and the PyPI-facing README

## Testing
- not run (docs only)

------
https://chatgpt.com/codex/tasks/task_e_68cacdad87b883308aeb9ad1593c77d8