### PR TITLE
Add Tkinter GUI with controller and smoke tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,3 +42,11 @@ Coding standards:
 - Docstrings with argument/return types and examples.
 - Keep runtime deps minimal; add extras behind optional groups if needed.
 - Follow ruff/black/mypy configs defined in pyproject.toml.
+
+UI maintenance:
+
+- The Tkinter UI under `src/furlan_g2p/ui/` mirrors the public contract of
+  `PipelineService`. When that contract changes (new outputs, altered
+  signatures, updated formatting), update the controller, widgets and
+  accompanying tests in `tests/test_ui_controller.py` and
+  `tests/test_ui_tk.py` to keep the graphical client in sync.

--- a/README.md
+++ b/README.md
@@ -106,6 +106,17 @@ For detailed documentation on component interactions and algorithmic design, con
    Notes:
    - Quotes around the phrase are recommended to preserve spacing and punctuation.
 
+## Graphical interface (Tkinter)
+
+The project ships with a lightweight desktop UI that wraps the
+``PipelineService``.  Launch it via ``furlang2p ui`` (after installing the
+package) or directly with ``python -m furlan_g2p.ui.tk_ui``.  The window offers
+a multi-line input editor, displays the normalized text alongside the
+space-separated phoneme sequence, and provides a dedicated "Copy output" button
+for quickly sharing the results.  The interface is implemented with Tkinter and
+ttk widgets; any change to the pipeline's public API should be reflected in the
+controller and tests under ``src/furlan_g2p/ui/`` and ``tests/test_ui_*.py``.
+
 ### Loading normalizer configuration
 
 Normalization rules can be customised via external JSON or YAML files. A helper

--- a/src/furlan_g2p/cli/app.py
+++ b/src/furlan_g2p/cli/app.py
@@ -127,6 +127,15 @@ def cmd_g2p(inp: str | None, out: str | None, fmt: str, sep: str, text: tuple[st
         click.echo(out_data)
 
 
+@cli.command("ui", help="Launch the Tkinter graphical interface.")
+def cmd_ui() -> None:
+    """Start the desktop UI."""
+
+    from ..ui import run as run_ui
+
+    run_ui([])
+
+
 @cli.command("phonemize-csv")
 @click.option("--in", "inp", required=True, help="Input metadata CSV (LJSpeech-like).")
 @click.option("--out", "out", required=True, help="Output CSV with phonemes added.")

--- a/src/furlan_g2p/ui/__init__.py
+++ b/src/furlan_g2p/ui/__init__.py
@@ -1,0 +1,7 @@
+"""Tkinter user interface for :mod:`furlan_g2p`."""
+
+from __future__ import annotations
+
+from .tk_ui import Application, UIController, run
+
+__all__ = ["Application", "UIController", "run"]

--- a/src/furlan_g2p/ui/tk_ui.py
+++ b/src/furlan_g2p/ui/tk_ui.py
@@ -1,0 +1,290 @@
+"""Tkinter-based graphical interface for the FurlanG2P pipeline."""
+
+from __future__ import annotations
+
+import argparse
+import tkinter as tk
+from collections.abc import Sequence
+from tkinter import messagebox, ttk
+from typing import Protocol
+
+from furlan_g2p.services.pipeline import PipelineService
+
+
+class MessageboxProtocol(Protocol):
+    """Protocol describing the subset of :mod:`tkinter.messagebox` we use."""
+
+    def showerror(self, title: str, message: str) -> None:  # pragma: no cover - Protocol
+        """Display an error dialog."""
+
+
+class UIController:
+    """Orchestrate calls to :class:`~furlan_g2p.services.pipeline.PipelineService`.
+
+    Parameters
+    ----------
+    pipeline:
+        Optional pipeline instance.  Tests inject a mock implementation to
+        validate the formatting logic without exercising the full pipeline.
+    messagebox_module:
+        Module exposing :func:`showerror`.  The default is
+        :mod:`tkinter.messagebox`, but allowing injection keeps the controller
+        deterministic during unit tests.
+
+    Notes
+    -----
+    For very long texts the processing step could run in a worker thread and
+    push results back to the UI via :meth:`tk.Misc.after`.  The current
+    implementation is synchronous to keep the tool lightweight.
+    """
+
+    def __init__(
+        self,
+        pipeline: PipelineService | None = None,
+        messagebox_module: MessageboxProtocol | None = None,
+    ) -> None:
+        self.pipeline = pipeline or PipelineService()
+        self._messagebox = messagebox_module or messagebox
+
+    def process(self, raw_text: str) -> str:
+        """Process ``raw_text`` and return a formatted string for display.
+
+        ``raw_text`` is left untouched so that the pipeline receives exactly
+        what the user entered.  When the pipeline raises an exception the
+        controller emits a non-blocking dialog and returns an empty string,
+        allowing the UI layer to decide how to react.
+        """
+
+        if not raw_text.strip():
+            return ""
+        try:
+            normalized, phonemes = self.pipeline.process_text(raw_text)
+        except Exception as exc:
+            self._messagebox.showerror(
+                "Processing error",
+                f"Unable to process the provided text. Details: {exc}",
+            )
+            return ""
+        return self.format_output(normalized, phonemes)
+
+    @staticmethod
+    def format_output(normalized: str, phonemes: Sequence[str]) -> str:
+        """Return the string shown in the output pane."""
+
+        phoneme_text = " ".join(phonemes).strip()
+        normalized_text = normalized.strip()
+
+        sections: list[str] = []
+        if normalized_text:
+            sections.append(f"Normalized:\n{normalized}")
+        elif normalized:
+            sections.append(f"Normalized:\n{normalized}")
+        if phoneme_text:
+            sections.append(f"Phonemes:\n{phoneme_text}")
+        return "\n\n".join(sections) if sections else ""
+
+
+class _ReadOnlyText(tk.Text):
+    """Text widget that disallows user edits while keeping selection enabled."""
+
+    _NAVIGATION_KEYS = {
+        "Left",
+        "Right",
+        "Up",
+        "Down",
+        "Home",
+        "End",
+        "Next",
+        "Prior",
+    }
+
+    def __init__(self, master: tk.Misc, **kwargs: object) -> None:
+        super().__init__(master, **kwargs)
+        self.configure(cursor="arrow", wrap="word", undo=False, takefocus=True)
+        self.bind("<Key>", self._on_keypress)
+        self.bind("<<Paste>>", lambda _event: "break")
+        self.bind("<<Cut>>", lambda _event: "break")
+        self.bind("<Button-1>", self._focus_on_click)
+        self.bind("<Button-2>", lambda _event: "break")
+        self.bind("<Button-3>", self._focus_on_click)
+
+    def _on_keypress(self, event: tk.Event) -> str | None:
+        if event.keysym in self._NAVIGATION_KEYS:
+            return None
+        if event.keysym in {"Shift_L", "Shift_R", "Control_L", "Control_R"}:
+            return None
+        if event.keysym == "Insert" and event.state & 0x1:  # Shift pressed
+            return "break"
+        if event.state & 0x4:  # Control pressed
+            lowered = event.keysym.lower()
+            if lowered in {"c", "a"} or event.keysym == "Insert":
+                return None
+        if event.keysym in {"BackSpace", "Delete", "Return", "KP_Enter", "Tab", "space"}:
+            return "break"
+        if len(event.keysym) == 1:
+            return "break"
+        return None
+
+    def _focus_on_click(self, event: tk.Event) -> None:
+        self.focus_set()
+
+
+class Application:
+    """Build and manage the Tkinter user interface."""
+
+    def __init__(self, root: tk.Tk, controller: UIController | None = None) -> None:
+        self.root = root
+        self.controller = controller or UIController()
+
+        self.root.title("FurlanG2P — GUI")
+        self.root.minsize(640, 480)
+        self._style = ttk.Style(self.root)
+        self._configure_style()
+        self._build_layout()
+        self._bind_events()
+        self._update_process_state()
+        self._update_copy_state()
+
+    def _configure_style(self) -> None:
+        """Apply a light modern theme."""
+
+        theme = self._style.theme_use()
+        if theme == "clam":
+            return
+        try:
+            self._style.theme_use("clam")
+        except tk.TclError:
+            self._style.theme_use(theme)
+        padding = {"padding": (8, 4)}
+        self._style.configure("TButton", **padding)
+        self._style.configure("TLabel", padding=(2, 2))
+
+    def _build_layout(self) -> None:
+        """Create widgets and arrange them using a responsive grid."""
+
+        self.root.columnconfigure(0, weight=1)
+        self.root.rowconfigure(0, weight=1)
+
+        main = ttk.Frame(self.root, padding=16)
+        main.grid(row=0, column=0, sticky="nsew")
+        main.columnconfigure(0, weight=1)
+        main.columnconfigure(1, weight=0)
+        main.rowconfigure(1, weight=1)
+        main.rowconfigure(3, weight=1)
+
+        ttk.Label(main, text="Input").grid(row=0, column=0, sticky="w")
+        self.input_text = tk.Text(main, wrap="word", height=8, undo=True)
+        self.input_text.grid(row=1, column=0, sticky="nsew", pady=(4, 12))
+        self.input_text.configure(font=("TkDefaultFont", 11))
+        input_scroll = ttk.Scrollbar(main, orient="vertical", command=self.input_text.yview)
+        input_scroll.grid(row=1, column=1, sticky="ns", pady=(4, 12), padx=(8, 0))
+        self.input_text.configure(yscrollcommand=input_scroll.set)
+
+        ttk.Label(main, text="Output").grid(row=2, column=0, sticky="w")
+        self.output_text = _ReadOnlyText(main, height=10)
+        self.output_text.grid(row=3, column=0, sticky="nsew", pady=(4, 12))
+        self.output_text.configure(font=("TkDefaultFont", 11))
+        output_scroll = ttk.Scrollbar(main, orient="vertical", command=self.output_text.yview)
+        output_scroll.grid(row=3, column=1, sticky="ns", pady=(4, 12), padx=(8, 0))
+        self.output_text.configure(yscrollcommand=output_scroll.set)
+
+        buttons = ttk.Frame(main)
+        buttons.grid(row=4, column=0, columnspan=2, sticky="e")
+        self.process_button = ttk.Button(buttons, text="Process", command=self.on_process)
+        self.process_button.grid(row=0, column=0, padx=(0, 8))
+        self.copy_button = ttk.Button(buttons, text="Copy output", command=self.on_copy_output)
+        self.copy_button.grid(row=0, column=1)
+
+    def _bind_events(self) -> None:
+        """Wire up widget events."""
+
+        self.input_text.bind("<<Modified>>", self._on_input_modified)
+        self.input_text.bind("<Control-Return>", self.on_process)
+        self.input_text.bind("<Control-KP_Enter>", self.on_process)
+        self.root.bind_all("<Alt-c>", self.on_copy_output)
+        self.root.bind_all("<Alt-C>", self.on_copy_output)
+
+    def _on_input_modified(self, _event: tk.Event) -> None:
+        self.input_text.edit_modified(False)
+        self._update_process_state()
+
+    def _update_process_state(self) -> None:
+        raw = self.get_input_text().strip()
+        if raw:
+            self.process_button.state(["!disabled"])
+        else:
+            self.process_button.state(["disabled"])
+
+    def _update_copy_state(self) -> None:
+        if self.get_output_text():
+            self.copy_button.state(["!disabled"])
+        else:
+            self.copy_button.state(["disabled"])
+
+    def get_input_text(self) -> str:
+        """Return the current input text without the trailing newline."""
+
+        return self.input_text.get("1.0", tk.END).rstrip("\n")
+
+    def get_output_text(self) -> str:
+        """Return the rendered output text."""
+
+        return self.output_text.get("1.0", tk.END).rstrip("\n")
+
+    def set_output_text(self, text: str) -> None:
+        """Replace the contents of the output widget."""
+
+        self.output_text.delete("1.0", tk.END)
+        if text:
+            self.output_text.insert("1.0", text)
+        self.output_text.see("1.0")
+
+    def on_process(self, event: tk.Event | None = None) -> str | None:
+        """Handle the "Process" action."""
+
+        result = self.controller.process(self.get_input_text())
+        self.set_output_text(result)
+        self._update_copy_state()
+        if event is not None:
+            return "break"
+        return None
+
+    def on_copy_output(self, event: tk.Event | None = None) -> str | None:
+        """Copy the entire output to the clipboard."""
+
+        text = self.get_output_text()
+        if not text:
+            return "break" if event is not None else None
+        self.root.clipboard_clear()
+        self.root.clipboard_append(text)
+        self.root.update()
+        if event is not None:
+            return "break"
+        return None
+
+
+def run(argv: Sequence[str] | None = None) -> None:
+    """Launch the Tkinter interface."""
+
+    parser = argparse.ArgumentParser(
+        prog="furlang2p ui",
+        description=(
+            "Launch the Tkinter interface to normalize text and view its phoneme "
+            "sequence."
+        ),
+    )
+    parser.add_argument(
+        "--geometry",
+        help="Optional Tk geometry string, for example 1024x768.",
+    )
+    args = parser.parse_args(argv if argv is not None else None)
+
+    root = tk.Tk()
+    if args.geometry:
+        root.geometry(args.geometry)
+    Application(root)
+    root.mainloop()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation helper
+    run()

--- a/tests/test_ui_controller.py
+++ b/tests/test_ui_controller.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from unittest.mock import Mock
+
+import pytest
+
+from furlan_g2p.ui.tk_ui import UIController
+
+
+@pytest.fixture
+def controller_with_mocks() -> tuple[UIController, Mock, Mock]:
+    pipeline = Mock()
+    messagebox = Mock()
+    controller = UIController(pipeline=pipeline, messagebox_module=messagebox)
+    return controller, pipeline, messagebox
+
+
+def test_process_formats_output(controller_with_mocks: tuple[UIController, Mock, Mock]) -> None:
+    controller, pipeline, messagebox = controller_with_mocks
+    pipeline.process_text.return_value = ("cjase", ["ˈc", "a", "z", "e"])
+
+    result = controller.process("Cjase")
+
+    pipeline.process_text.assert_called_once_with("Cjase")
+    assert result == "Normalized:\ncjase\n\nPhonemes:\nˈc a z e"
+    messagebox.showerror.assert_not_called()
+
+
+def test_process_ignores_empty_input(
+    controller_with_mocks: tuple[UIController, Mock, Mock],
+) -> None:
+    controller, pipeline, messagebox = controller_with_mocks
+
+    result = controller.process("   \n\t")
+
+    assert result == ""
+    pipeline.process_text.assert_not_called()
+    messagebox.showerror.assert_not_called()
+
+
+def test_process_reports_errors(controller_with_mocks: tuple[UIController, Mock, Mock]) -> None:
+    controller, pipeline, messagebox = controller_with_mocks
+    pipeline.process_text.side_effect = RuntimeError("boom")
+
+    result = controller.process("ciao")
+
+    assert result == ""
+    messagebox.showerror.assert_called_once()

--- a/tests/test_ui_tk.py
+++ b/tests/test_ui_tk.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from collections.abc import Generator
+from unittest.mock import Mock
+
+import pytest
+
+try:
+    import tkinter as tk
+except Exception:  # pragma: no cover - handled in fixture
+    tk = None  # type: ignore[assignment]
+
+from furlan_g2p.ui.tk_ui import Application
+
+
+@pytest.fixture
+def tk_root() -> Generator[tk.Tk, None, None]:
+    if tk is None:
+        pytest.skip("tkinter is not available")
+    try:
+        root = tk.Tk()
+    except tk.TclError as exc:  # pragma: no cover - depends on CI
+        pytest.skip(f"Tk cannot create a root window: {exc}")
+    root.withdraw()
+    yield root
+    root.destroy()
+
+
+def test_process_updates_output(tk_root: tk.Tk) -> None:
+    controller = Mock()
+    controller.process.return_value = "Normalized:\ncjase\n\nPhonemes:\nˈc a z e"
+    app = Application(tk_root, controller=controller)
+
+    app.input_text.insert("1.0", "Cjase")
+    app.on_process()
+    tk_root.update_idletasks()
+
+    assert app.get_output_text() == "Normalized:\ncjase\n\nPhonemes:\nˈc a z e"
+    controller.process.assert_called_once_with("Cjase")
+
+
+def test_copy_button_uses_clipboard(tk_root: tk.Tk, monkeypatch: pytest.MonkeyPatch) -> None:
+    controller = Mock()
+    controller.process.return_value = "Normalized:\nfoo\n\nPhonemes:\nbar"
+    app = Application(tk_root, controller=controller)
+    app.input_text.insert("1.0", "foo")
+    app.on_process()
+
+    cleared = []
+    appended: list[str] = []
+
+    def fake_clear() -> None:
+        cleared.append("clear")
+
+    def fake_append(value: str) -> None:
+        appended.append(value)
+
+    monkeypatch.setattr(tk_root, "clipboard_clear", fake_clear)
+    monkeypatch.setattr(tk_root, "clipboard_append", fake_append)
+    monkeypatch.setattr(tk_root, "update", lambda: None)
+
+    app.on_copy_output()
+
+    assert cleared == ["clear"]
+    assert appended == ["Normalized:\nfoo\n\nPhonemes:\nbar"]
+
+
+def test_process_button_state_tracks_input(tk_root: tk.Tk) -> None:
+    controller = Mock()
+    app = Application(tk_root, controller=controller)
+
+    assert "disabled" in app.process_button.state()
+
+    app.input_text.insert("1.0", "ciao")
+    app.input_text.event_generate("<<Modified>>")
+    tk_root.update_idletasks()
+
+    assert "disabled" not in app.process_button.state()
+
+    app.input_text.delete("1.0", tk.END)
+    app.input_text.event_generate("<<Modified>>")
+    tk_root.update_idletasks()
+
+    assert "disabled" in app.process_button.state()


### PR DESCRIPTION
## Summary
- add a Tkinter-based desktop UI that wraps the PipelineService with processing and copy controls
- export the UI module for reuse and wire a `furlang2p ui` CLI subcommand, updating docs and agent guidance
- cover the controller logic and GUI behaviour with pytest-based unit and smoke tests

## Testing
- PYTHONPATH=src pytest tests/test_ui_controller.py -q
- PYTHONPATH=src pytest tests/test_ui_tk.py -q

------
https://chatgpt.com/codex/tasks/task_e_68cc656bbcec8330857ae0ec41219bb0